### PR TITLE
Add Blast Radius CI workflow

### DIFF
--- a/.blast-radius.json
+++ b/.blast-radius.json
@@ -1,0 +1,5 @@
+{
+  "unresolved": {
+    "ignore": ["/dist/"]
+  }
+}

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,0 +1,13 @@
+name: blast-radius
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  blast-radius:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ehermanson/blast-radius@v0.8.0


### PR DESCRIPTION
Adds the [Blast Radius](https://github.com/marketplace/actions/blast-radius-change-impact) change-impact action on `pull_request`.

- `.github/workflows/blast-radius.yml` — runs `ehermanson/blast-radius@v0.8.0` on every PR, with `pull-requests: write` so it can post its report comment
- `.blast-radius.json` — ignores unresolved imports under `/dist/`

Runs with action defaults (no `fail-on-risk` configured) — report-only, non-gating.