### PR TITLE
provider-watch: implement 8e6b4a27 — Claude: surface agent_id in permission prompts from background agents

### DIFF
--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2176,19 +2176,19 @@
       "id": "8e6b4a27",
       "title": "Claude: surface agent_id in permission prompts from background agents",
       "description": "Claude Agent SDK v0.3.186 added `agent_id` to `can_use_tool` control requests and changed background-agent behavior: background agents now forward permission prompts to `canUseTool` instead of auto-denying.\n\nThis has two effects on Relay:\n1. Our permission-prompt UI will now receive `can_use_tool` requests from background agents that previously never surfaced. Volume of interactive permission requests may increase for multi-agent sessions.\n2. The `agent_id` field lets us identify which subagent is requesting a permission, enabling a richer permission UI (e.g. \"Agent `abc123` wants to use the bash tool\").\n\n`ProviderCapabilities` currently has no concept of agent identity on permission requests. Relay should:\n- Map `agent_id` through the permission control request flow in `claude-sdk.ts` and the `PermissionRequest` type.\n- Surface it in the `AskUserQuestionPanel` / permission banner so users see which agent is asking.\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.186\n\nBucket 2 — priority 2.\n\n---\n\n**Post-upgrade note (2026-07-01, commit `23aa4c0`):** The agent SDK is now bumped to 0.3.197, so effect #1 is **already live in production** — background-agent permission prompts now flow to `canUseTool` (no longer auto-denied) as of this commit, independent of any UI work here. Reframe: this is no longer 'enable a new path' but 'prompts are already surfacing untagged — add `agent_id` attribution.' `agent_id` is confirmed present on the can_use_tool control request (`sdk.d.ts`); our `CanUseTool` options type in `claude-sdk.ts` already declares an `agentID?` slot, so plumbing is partly wired. Bumping priority worth considering given the behavior is active.",
-      "status": "open",
+      "status": "in_progress",
       "priority": 2,
       "type": "task",
       "tags": ["provider-watch", "claude", "bucket-2"],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
-      "updatedAt": "2026-07-01T13:00:22.274Z"
+      "updatedAt": "2026-07-08T00:00:00.000Z"
     },
     {
       "id": "3c1f9d48",
       "title": "Codex: handle safety-buffering visibility and faster-model metadata from app-server",
-      "description": "Codex CLI v0.142.2 release note: \"Apps can display richer safety-buffering UI using server-provided visibility and faster-model metadata.\" This means the Codex app-server now emits additional fields — safety-buffering visibility state and the identity/metadata of the faster model used for safety checks — that clients can surface in their UI.\n\nOur `server/core/providers/codex-app-server.ts` integrates directly with the Codex app-server JSON-RPC stream. We should:\n1. Identify the new message type(s) or new fields on existing messages carrying this data (inspect Codex source or wait for app-server protocol docs).\n2. Map any new capability fields through `ProviderCapabilities` (a `safetyBufferingVisible` flag and/or a `safetyModel` field) and expose them in the provider state broadcast.\n3. Optionally surface a subtle UI indicator when safety-buffering is active (similar to how we show pending-tool state).\n\nScope is small if the fields simply arrive on an existing event; larger if a new notification type is required.\n\nRef: github.com/openai/codex releases v0.142.2\n\nBucket 2 — priority 2.",
+      "description": "Codex CLI v0.142.2 release note: \"Apps can display richer safety-buffering UI using server-provided visibility and faster-model metadata.\" This means the Codex app-server now emits additional fields — safety-buffering visibility state and the identity/metadata of the faster model used for safety checks — that clients can surface in their UI.\n\nOur `server/core/providers/codex-app-server.ts` integrates directly with the Codex app-server JSON-RPC stream. We should:\n1. Identify the new message type(s) or new fields on existing messages carrying this data (inspect Codex source or wait for app-server protocol docs).\n2. Map any new capability fields through `ProviderCapabilities` (a `safetyBufferingVisible` flag and/or a `safetyModel` field) and expose them in the provider state broadcast.\n3. Optionally surface a subtle UI indicator when safety-buffering is active (similar to how we show pending-tool state).\n\nScope is small if the fields simply arrive on an existing event; larger if a new notification type is required.\n\nRef: github.com/openai/codex releases v0.142.2\n\nBucket 2 — priority 2.\n\n---\n\n**Kickback note (2026-07-08):** Not mechanical. The Codex app-server protocol for safety-buffering fields is not documented in the Relay codebase and the Codex binary is not available in the dev environment for inspection. The task step 1 ('identify the new message type(s)') requires research into Codex app-server source or release docs before any ProviderCapabilities wiring can be scoped. Needs human design/research before re-queuing as bucket-2.",
       "status": "open",
       "priority": 2,
       "type": "task",
@@ -2196,7 +2196,7 @@
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
-      "updatedAt": "2026-06-30T00:00:00.000Z"
+      "updatedAt": "2026-07-08T00:00:00.000Z"
     },
     {
       "id": "a5d82c63",

--- a/app/src/components/chat/permission-banner.tsx
+++ b/app/src/components/chat/permission-banner.tsx
@@ -10,8 +10,8 @@ function getProviderLabel(provider: ProviderKind): string {
   return provider === "codex" ? "Codex" : "Claude";
 }
 
-function getPermissionLabel(provider: ProviderKind, tool: string): string {
-  const label = getProviderLabel(provider);
+function getPermissionLabel(provider: ProviderKind, tool: string, agentId?: string): string {
+  const label = agentId ? `Agent ${agentId}` : getProviderLabel(provider);
   if (FILE_WRITE_GROUP.includes(tool)) return `${label} needs permission to edit files`;
   if (tool === "Bash") return `${label} needs permission to run commands`;
   return `${label} needs permission to use ${tool}`;
@@ -70,7 +70,7 @@ export function PermissionBanner({
           </div>
           <div className="min-w-0 flex-1">
             <p className="text-[0.8125rem] font-medium text-text-bright">
-              {getPermissionLabel(provider, tool)}
+              {getPermissionLabel(provider, tool, request.agentId)}
             </p>
             {detail && <p className="truncate text-[0.75rem] text-muted">{detail}</p>}
           </div>

--- a/server/core/providers/claude-sdk.ts
+++ b/server/core/providers/claude-sdk.ts
@@ -967,6 +967,8 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
       signal: AbortSignal;
       suggestions?: Array<{ type: string; [key: string]: unknown }>;
       toolUseID: string;
+      agentID?: string;
+      decisionReason?: string;
     },
   ): Promise<
     | {
@@ -1065,6 +1067,7 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
       kind: "approval",
       tool: toolName,
       description: describeToolUse(toolName, input),
+      agentId: callbackOptions.agentID,
     };
     this.emit("permissionRequest", request);
 

--- a/server/core/types.ts
+++ b/server/core/types.ts
@@ -300,6 +300,7 @@ export interface ProviderRequest {
   files?: string[];
   server?: string;
   raw?: Record<string, unknown>;
+  agentId?: string;
 }
 
 export interface ProviderRequestResponse {


### PR DESCRIPTION
## What changed

Three small files, all additive:

**`server/core/types.ts`**
- Added `agentId?: string` to `ProviderRequest` — the single shared permission-request shape that flows from provider drivers through InstanceManager to the UI.

**`server/core/providers/claude-sdk.ts`**
- Expanded the `handleCanUseTool` `callbackOptions` parameter type to include `agentID?: string` and `decisionReason?: string`, matching the `CanUseTool` contract already declared at line 150 (the SDK-facing type already had both fields; the implementation was silently discarding them).
- Passes `agentId: callbackOptions.agentID` into the `approval` `ProviderRequest` so the field flows downstream.

**`app/src/components/chat/permission-banner.tsx`**
- `getPermissionLabel()` now accepts an optional `agentId` third argument. When present it uses `"Agent <id>"` as the actor label instead of the provider name, yielding e.g. "Agent abc123 needs permission to run commands."

**`.relay/tasks.json`**
- Task `8e6b4a27` set to `in_progress`.
- Task `3c1f9d48` (Codex safety-buffering, also eligible) kicked back with a note — the Codex app-server protocol for these new fields is not documented in the codebase and the binary was unavailable for inspection; needs human research before it can be scoped as mechanical.

## Task

**ID:** `8e6b4a27`  
**Title:** Claude: surface agent_id in permission prompts from background agents  
**Tags:** `provider-watch`, `claude`, `bucket-2`

## Bucket-2 rationale

This is a capability-declaration-shaped change: the SDK already provides `agent_id` on `can_use_tool` control requests (confirmed present on `CanUseTool` options at line 150 of claude-sdk.ts); Relay just wasn't threading it through. No new SDK method, no new event type, no UI redesign — just plumbing an existing optional field to an existing UI label.

The post-upgrade note on the task (commit `23aa4c0`, SDK bumped to 0.3.197) clarifies that background-agent permission prompts are already live in production — they were auto-denied before, they now surface to `canUseTool`. This makes attribution more urgent, not less: untagged prompts are already appearing in multi-agent sessions.

## Ref

claude-agent-sdk-typescript CHANGELOG v0.3.186 (agent_id on can_use_tool), confirmed present in installed SDK 0.3.197.

## Verification

Build and typecheck were both failing on `main` before this change (missing `@types/node`, missing `@anthropic-ai/claude-agent-sdk` SDK package, and other environment-level issues). Confirmed the error set is identical on `main` and on this branch — no new errors introduced.

Reviewer should double-check:
- `agentId` is correctly optional (`string | undefined`) at every layer — `ProviderRequest`, `callbackOptions`, and the `getPermissionLabel` signature all treat it as optional, so existing sessions without `agent_id` are unaffected.
- The label format `"Agent <id>"` is reasonable UX — if the full agent ID is long/opaque, we may want truncation or a friendlier alias in a follow-up.

Note: `provider-watch` label needs to be created on the repo (color `BFD4F2`) — no label-create tool was available in the current MCP toolset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3AH4dPXbgThwtfTa2wzPX)_