### PR TITLE
provider-watch: triage 2026-06-30 → 2026-07-13

### DIFF
--- a/.relay/changelog-watch-state.json
+++ b/.relay/changelog-watch-state.json
@@ -1,8 +1,8 @@
 {
-  "claude-code-cli": "2.1.197",
-  "claude-agent-sdk": "0.3.197",
-  "anthropic-sdk": "0.109.0",
-  "codex-cli": "0.142.4",
-  "codex-app-server": "0.142.4",
-  "lastRunAt": "2026-06-30T00:00:00.000Z"
+  "claude-code-cli": "2.1.207",
+  "claude-agent-sdk": "0.3.207",
+  "anthropic-sdk": "0.111.0",
+  "codex-cli": "0.144.3",
+  "codex-app-server": "0.144.3",
+  "lastRunAt": "2026-07-13T00:00:00.000Z"
 }

--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2223,6 +2223,45 @@
       "blockedBy": [],
       "createdAt": "2026-07-01T16:15:00.000Z",
       "updatedAt": "2026-07-01T16:15:00.000Z"
+    },
+    {
+      "id": "c4e91a73",
+      "title": "Anthropic SDK: evaluated_permission gating and idle stop_reason (0.111.0 heads-up)",
+      "description": "Two contract changes land in `@anthropic-ai/sdk` 0.111.0 (2026-07-10) that Relay must audit before the next SDK pin bump:\n\n1. **`evaluated_permission` gating**: Session tool calls are now gated on an `evaluated_permission` result before they execute. This is a semantic change to the SDK's tool-call flow — the permission decision is no longer purely client-side. Relay's `canUseTool` callback and permission-request plumbing in `claude-sdk.ts` must be verified to still work correctly under this model.\n\n2. **`idle` stop_reason**: The server can now return `stop_reason: 'idle'` to bound a session turn that ends because the session went idle (rather than completing or being interrupted). Our `handleResult` in `claude-sdk.ts` treats `stop_reason` as an opaque string and ends the turn normally — this is safe — but we should verify the resulting turn state is emitted correctly (not as an error) and that the session is not left in a hung state.\n\nNote: `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET` is still unaffected per 0.111.0 changelog; still safe to rely on until stabilization rename.\n\nRelated: prior SDK upgrade task `b9c34e12` (done, covered 0.100.1→0.109.0). This task covers 0.109.0→0.111.0 delta.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md (v0.110.0, v0.111.0)\n\nBucket 0 — priority 1.",
+      "status": "open",
+      "priority": 1,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-0"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-13T00:00:00.000Z",
+      "updatedAt": "2026-07-13T00:00:00.000Z"
+    },
+    {
+      "id": "d7f03b28",
+      "title": "Codex: add `writes` approval mode to ProviderCapabilities.runtimeModes",
+      "description": "Codex CLI v0.144.0 (2026-07-09) added a `writes` app-approval mode: declared read-only tool calls are auto-allowed; only write-access tool calls prompt for approval. This is a third `approvalPolicy` value alongside the existing `on-request` and `never`.\n\nRelay's `resolveApprovalPolicy()` in `server/core/providers/codex-app-server.ts` currently maps `full-access → 'never'` and everything else → `'on-request'`. The `writes` mode has no Relay representation:\n\n1. Add `'writes-only'` (or similar Relay-canonical name) to `ProviderRuntimeMode` and map it to Codex `approvalPolicy: 'writes'` in `resolveApprovalPolicy()`.\n2. Add an entry to `ProviderCapabilities.runtimeModes` for Codex so the UI renders the new option in the runtime-mode picker (label, description, icon — driven by capability metadata, never hardcoded in the UI).\n3. Verify the Codex app-server actually accepts `writes` on the `turn/start` or `session/init` RPC — confirm the field name from the codex source or app-server protocol docs.\n4. Update `ProviderRuntimeMode` union type in `server/core/types.ts`, the DB column values if needed, and any downstream switch exhaustion checks.\n\nRef: https://github.com/openai/codex/releases/tag/v0.144.0\n\nBucket 2 — priority 2.",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": ["provider-watch", "codex", "bucket-2"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-13T00:00:00.000Z",
+      "updatedAt": "2026-07-13T00:00:00.000Z"
+    },
+    {
+      "id": "e2a81c94",
+      "title": "Claude: expose auto mode as a runtime-mode capability option",
+      "description": "Claude Code CLI v2.1.207 (2026-07-11) made auto mode generally available without the `CLAUDE_CODE_ENABLE_AUTO_MODE` env-var opt-in on Bedrock, Vertex AI, and Foundry. It can be disabled via `disableAutoMode` in `~/.claude/settings.json`.\n\nAuto mode is a distinct permission-management model: a safety classifier automatically approves or rejects each tool call without user prompts — between the current `approval-required` (prompt everything) and `full-access` (allow everything) modes in Relay's `ProviderRuntimeMode`.\n\nCurrently Relay has no representation for auto mode:\n\n1. **Determine SDK surface**: check whether the Claude Agent SDK exposes auto mode as a `permissionMode` value (likely `permissionMode: 'auto'`) or whether it requires a separate session argument / settings injection. The Claude Code CLI docs and SDK changelog are the reference.\n2. **Add to `ProviderCapabilities`**: add `autoMode` to `ProviderCapabilities.runtimeModes` (or as a boolean `autoMode` capability flag) for the Claude driver. Scope the flag to platforms where it is actually supported (Bedrock, Vertex, Foundry — not necessarily the standard API).\n3. **Provider driver**: map the new Relay runtime mode to the correct SDK arg in `claude-sdk.ts`.\n4. **UI**: the runtime-mode picker already renders from `ProviderCapabilities.runtimeModes` metadata — ensure label and description copy are added.\n5. **`disableAutoMode` setting**: if users have this set, Relay should not offer auto mode as an option (or surface a warning). Consider reading from `~/.claude/settings.json` in the provider version probe and reflecting it in capabilities.\n\nNote: `permissionMode: 'manual'` is now an accepted alias for `'default'` in the SDK (v0.3.200) — no change needed, `'default'` still works. The auto mode capability is the new surface.\n\nRef: https://github.com/anthropics/claude-code/releases/tag/v2.1.207, claude-agent-sdk-typescript CHANGELOG v0.3.200\n\nBucket 2 — priority 2.",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-2"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-13T00:00:00.000Z",
+      "updatedAt": "2026-07-13T00:00:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
Weekly provider changelog triage. Watermarks advanced for all five sources. 3 tasks filed.

---

## Breaking / Deprecation (Bucket 0)

### ⚠️ Anthropic SDK 0.111.0: `evaluated_permission` gating + new `idle` stop_reason

Two contract changes in `@anthropic-ai/sdk` 0.111.0 (2026-07-10) that must be audited before the next SDK pin bump (currently 0.100.1, triage watermark now 0.111.0):

- **`evaluated_permission` gating** — session tool calls are now gated on a server-evaluated permission result before they execute. This shifts part of the permission decision server-side. Relay's `canUseTool` callback and permission-request plumbing in `claude-sdk.ts` need verification.
- **`idle` stop_reason** — the server can now return `stop_reason: 'idle'` when a session ends due to inactivity rather than completion or interruption. Our `handleResult` is permissive enough (opaque string) but session state on idle termination should be confirmed.

**Task filed**: `c4e91a73` — priority 1.

---

## "Would've been Bucket 2 if we had abstraction X"

- **Claude Agent SDK 0.3.206: `command_lifecycle` frames** — each UUID-stamped message now reports its terminal state (`queued/started/completed/cancelled/discarded`). Would be bucket-2 if Relay tracked per-command status (vs. per-turn). Note for future: a `CommandLifecycle` abstraction in the provider driver contract would make this a mechanical add.

- **Claude Agent SDK 0.3.203: `background_tasks_changed` system message** — fires a full snapshot of live background tasks on every membership change, eliminating the need to pair `task_started`/`task_notification` edges. Would be bucket-2 if Codex had an equivalent event (today it's Claude-only). Note for future integration simplification.

- **Codex 0.143.0: app-server `fork history through specific turns`** — already covered by open task `a5d82c63` (session branching design). No new task.

---

## Tasks Filed

| ID | Title | Bucket | Priority |
|----|-------|--------|----------|
| `c4e91a73` | Anthropic SDK: `evaluated_permission` gating and `idle` stop_reason (0.111.0 heads-up) | Bucket 0 | 1 |
| `d7f03b28` | Codex: add `writes` approval mode to ProviderCapabilities.runtimeModes | Bucket 2 | 2 |
| `e2a81c94` | Claude: expose auto mode as a runtime-mode capability option | Bucket 2 | 2 |

### Bucket 2 detail

**`d7f03b28` — Codex `writes` approval mode** (Codex 0.144.0)
Codex added a `writes` `approvalPolicy` value: read-only tool calls auto-allowed, write calls prompt. Relay's `resolveApprovalPolicy()` currently maps to `on-request` or `never` only. Needs a new `ProviderRuntimeMode` variant, a `ProviderCapabilities.runtimeModes` entry for Codex, and driver mapping in `codex-app-server.ts`.

**`e2a81c94` — Claude auto mode** (Claude Code 2.1.207)
Auto mode is now GA without `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in on Bedrock, Vertex AI, and Foundry. It's a third permission-management model (classifier-driven, between `approval-required` and `full-access`). Relay has no `ProviderRuntimeMode` entry or `ProviderCapabilities` flag for it. Needs SDK surface discovery, driver mapping in `claude-sdk.ts`, and a runtime-mode picker entry.

---

## Bucket 1 "Free" (no action)

- **Claude Code 2.1.198**: Subagents run in background by default; Claude in Chrome GA; `/dataviz` skill added — transparent, CLI/browser-extension changes.
- **Claude Code 2.1.199**: Stacked skill invocations load up to 5 leading skills — free.
- **Claude Code 2.1.200**: Default permission mode renamed "Manual" (`'manual'` alias added in Agent SDK 0.3.200, `'default'` still works) — no Relay change needed.
- **Claude Code 2.1.201**: Sonnet 5 no longer uses mid-conversation system role — transparent SDK behavior.
- **Claude Code 2.1.202**: "Dynamic workflow size" setting, `workflow.run_id` OTel attributes — CLI-level settings.
- **Claude Code 2.1.203**: Login expiry warnings, MCP `roots/list` additions, macOS stall fix — transparent.
- **Claude Code 2.1.205**: Auto-mode tampering rule, auto-update streaming — transparent.
- **Claude Code 2.1.206**: `/cd` path suggestions, `/doctor` improvements — CLI UX, transparent. (`EnterWorktree` now confirms before entering paths outside `.claude/worktrees/` — Relay starts sessions in the worktree CWD directly, doesn't use this tool, not a concern.)
- **Claude Code 2.1.207**: Security fix: `${user_config.*}` in shell-form plugin hooks rejected; plugin options no longer read from project-level settings — Relay doesn't configure plugins via project-level settings.
- **Claude Agent SDK 0.3.198**: Per-server `request_timeout_ms` on `mcp_set_servers`; synthetic message mapping fix — transparent.
- **Claude Agent SDK 0.3.199**: `requestId` on `canUseTool`; `blocked` field on `workflow_agent` events — marginal; noted but not filed (Relay doesn't currently surface the auto-mode blocked state).
- **Claude Agent SDK 0.3.200**: `'manual'` alias for `'default'` permission mode; `onSetPermissionMode` bug fix for Remote Control sessions — free (backward-compatible alias; bug fix picked up on next SDK bump).
- **Claude Agent SDK 0.3.201–0.3.207**: Parity updates, cancel fix, `still_queued` in interrupt receipts, `AgentToolCompletedOutput` type, `canUseTool` ZodError fix — transparent.
- **Anthropic SDK 0.110.0**: `agent-memory-2026-07-22` beta header — no Relay impact.
- **Codex 0.143.0**: Remote plugins enabled by default; system proxy support; macOS/Windows ConPTY fixes; new Bedrock models (GPT-5.6 Sol/Terra/Luna) — model discovery is dynamic via app-server, no catalog update needed; other changes transparent.
- **Codex 0.143.0**: `codex remote-control pair` command — different pairing model from Relay's architecture, out-of-lane.
- **Codex 0.144.0**: MCP interactive auth without opt-in; credit type/expiration display — transparent or handled by existing Codex rate-limit UI path.
- **Codex 0.144.1–0.144.3**: Standalone install fixes, Guardian policy rollback, version bump — transparent.

---

## Out-of-Lane / Skipped

- **Claude in Chrome GA** (2.1.198) — single-provider browser extension, inner-loop UX Relay doesn't mediate.
- **Claude Platform on AWS / Gateway endpoints** (2.1.198, 2.1.206) — deployment/infra for Anthropic-hosted runners, not a Relay integration concern.
- **Codex app-server authentication hosting** (0.144.0) — Codex hosting its own auth redirect; Relay has its own auth layer.
- **Claude Agent SDK 0.3.202: `parent_agent_id`** — partially covered by open bucket-3 task `803fe57b` (nested subagent activity view); no new task.
- **Claude Agent SDK 0.3.204: richer `terminal_reason` values** — useful but no provider-neutral taxonomy yet; would be bucket-2 with a `SessionTerminalReason` abstraction in `ProviderCapabilities`. Skipped for now.

---

## Watermarks Advanced

| Source | Previous | New |
|--------|----------|-----|
| claude-code-cli | 2.1.197 | 2.1.207 |
| claude-agent-sdk | 0.3.197 | 0.3.207 |
| anthropic-sdk | 0.109.0 | 0.111.0 |
| codex-cli | 0.142.4 | 0.144.3 |
| codex-app-server | 0.142.4 | 0.144.3 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01JawwdhqD33kfychGESvYWk)_