### PR TITLE
provider-watch: implement d7f03b28 — Codex: add `writes` approval mode to ProviderCapabilities.runtimeModes

### DIFF
--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2241,27 +2241,27 @@
       "id": "d7f03b28",
       "title": "Codex: add `writes` approval mode to ProviderCapabilities.runtimeModes",
       "description": "Codex CLI v0.144.0 (2026-07-09) added a `writes` app-approval mode: declared read-only tool calls are auto-allowed; only write-access tool calls prompt for approval. This is a third `approvalPolicy` value alongside the existing `on-request` and `never`.\n\nRelay's `resolveApprovalPolicy()` in `server/core/providers/codex-app-server.ts` currently maps `full-access \u2192 'never'` and everything else \u2192 `'on-request'`. The `writes` mode has no Relay representation:\n\n1. Add `'writes-only'` (or similar Relay-canonical name) to `ProviderRuntimeMode` and map it to Codex `approvalPolicy: 'writes'` in `resolveApprovalPolicy()`.\n2. Add an entry to `ProviderCapabilities.runtimeModes` for Codex so the UI renders the new option in the runtime-mode picker (label, description, icon \u2014 driven by capability metadata, never hardcoded in the UI).\n3. Verify the Codex app-server actually accepts `writes` on the `turn/start` or `session/init` RPC \u2014 confirm the field name from the codex source or app-server protocol docs.\n4. Update `ProviderRuntimeMode` union type in `server/core/types.ts`, the DB column values if needed, and any downstream switch exhaustion checks.\n\nRef: https://github.com/openai/codex/releases/tag/v0.144.0\n\nBucket 2 \u2014 priority 2.",
-      "status": "open",
+      "status": "done",
       "priority": 2,
       "type": "task",
       "tags": ["provider-watch", "codex", "bucket-2"],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-13T00:00:00.000Z",
-      "updatedAt": "2026-07-13T00:00:00.000Z"
+      "updatedAt": "2026-07-16T00:00:00.000Z"
     },
     {
       "id": "e2a81c94",
       "title": "Claude: expose auto mode as a runtime-mode capability option",
       "description": "Claude Code CLI v2.1.207 (2026-07-11) made auto mode generally available without the `CLAUDE_CODE_ENABLE_AUTO_MODE` env-var opt-in on Bedrock, Vertex AI, and Foundry. It can be disabled via `disableAutoMode` in `~/.claude/settings.json`.\n\nAuto mode is a distinct permission-management model: a safety classifier automatically approves or rejects each tool call without user prompts \u2014 between the current `approval-required` (prompt everything) and `full-access` (allow everything) modes in Relay's `ProviderRuntimeMode`.\n\nCurrently Relay has no representation for auto mode:\n\n1. **Determine SDK surface**: check whether the Claude Agent SDK exposes auto mode as a `permissionMode` value (likely `permissionMode: 'auto'`) or whether it requires a separate session argument / settings injection. The Claude Code CLI docs and SDK changelog are the reference.\n2. **Add to `ProviderCapabilities`**: add `autoMode` to `ProviderCapabilities.runtimeModes` (or as a boolean `autoMode` capability flag) for the Claude driver. Scope the flag to platforms where it is actually supported (Bedrock, Vertex, Foundry \u2014 not necessarily the standard API).\n3. **Provider driver**: map the new Relay runtime mode to the correct SDK arg in `claude-sdk.ts`.\n4. **UI**: the runtime-mode picker already renders from `ProviderCapabilities.runtimeModes` metadata \u2014 ensure label and description copy are added.\n5. **`disableAutoMode` setting**: if users have this set, Relay should not offer auto mode as an option (or surface a warning). Consider reading from `~/.claude/settings.json` in the provider version probe and reflecting it in capabilities.\n\nNote: `permissionMode: 'manual'` is now an accepted alias for `'default'` in the SDK (v0.3.200) \u2014 no change needed, `'default'` still works. The auto mode capability is the new surface.\n\nRef: https://github.com/anthropics/claude-code/releases/tag/v2.1.207, claude-agent-sdk-typescript CHANGELOG v0.3.200\n\nBucket 2 \u2014 priority 2.",
-      "status": "in_progress",
+      "status": "done",
       "priority": 2,
       "type": "task",
       "tags": ["provider-watch", "claude", "bucket-2"],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-13T00:00:00.000Z",
-      "updatedAt": "2026-07-15T00:00:00.000Z"
+      "updatedAt": "2026-07-16T00:00:00.000Z"
     },
     {
       "id": "ffbc884b",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ Spaces group multiple concurrent agent chats within a shared git worktree/branch
 
 - `ProviderCapabilities.versionAdvisory` carries the result of the provider-version probe: installed CLI version vs latest npm-published version, detected install method, and the recommended update command
 - Probe runs in `server/core/provider-versions.ts` (pure helpers + `buildVersionAdvisory`); `server/core/provider-registry.ts` caches the result in-memory and refreshes every 30 min
+- Provider capabilities may be filtered by the installed version after probing. Codex `writes-only` is exposed only for CLI >= 0.144.0; before the probe resolves, version-gated controls remain hidden.
 - Latest-version lookup hits the npm registry with a 1h in-memory cache; `POST /api/providers/recheck-version` force-bypasses the cache (used by the settings "Re-check" button)
 - `POST /api/providers/update?provider=<kind>` runs the advisory's update command server-side (`runProviderUpdate` in `provider-registry.ts`): the command is always server-derived from `buildUpdateCommand` (never client-supplied), executed shell-less via `execFile` with a 10-min timeout; concurrent requests per provider share one run, and the advisory is force re-probed afterward. Automatic update is offered only for detected non-manual install methods; manual installs keep a copyable recommendation but are not run server-side.. Automatic update is offered only for detected non-manual install methods; manual installs keep a copyable recommendation but are not run server-side.
 - UI surfaces a one-shot sonner toast at app launch via `app/src/components/provider-update-notification.tsx`; dismissals persist per (provider, latestVersion) key in localStorage (`use-dismissed-provider-advisories.ts`)
@@ -196,7 +197,7 @@ Spaces group multiple concurrent agent chats within a shared git worktree/branch
 ### Codex Process Spawning
 
 - Every `codex app-server` spawn must build its environment with `buildCodexSpawnEnv()` (`server/core/providers/codex-cli.ts`), never raw `process.env`. It inherits the process env and, when unset, injects `CODEX_CODE_MODE_HOST_PATH` pointing at the `codex-code-mode-host` binary bundled inside ChatGPT.app. Codex "code mode" shells out to that helper but it isn't on PATH, so without this injection `turn/start` fails with `failed to spawn code-mode host ...: No such file or directory`. A user-provided `CODEX_CODE_MODE_HOST_PATH` always wins.
-- `resolveApprovalPolicy()` maps `full-access` → `never` and everything else → `on-request`. Codex dropped the old `on-failure` variant; valid values are `untrusted`/`on-request`/`granular`/`never`.
+- `resolveApprovalPolicy()` maps `full-access` → `never`, `writes-only` → `writes`, and everything else → `on-request`. Codex dropped the old `on-failure` variant; valid values include `untrusted`/`on-request`/`granular`/`never`/`writes` (with `writes` requiring CLI >= 0.144.0).
 
 ### Model Options
 
@@ -206,6 +207,7 @@ Spaces group multiple concurrent agent chats within a shared git worktree/branch
 - `model_options_json` column on `managed_sessions` is the canonical storage for provider-agnostic model tuning
 - `set_model_options` WS message does sparse merge (omitted = untouched, `null` = clear)
 - `ProviderCapabilities` includes control metadata (`reasoningEffortLevels`, `runtimeModes`, `fastModes`) — UI renders labels/descriptions from these, never hardcodes provider-specific text
+- Claude `auto` is an environment-dependent runtime mode: expose it only for Bedrock, Vertex, Foundry, or explicit `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in, and never when user settings contain `disableAutoMode: "disable"`.
 - `ReasoningEffort` uses `"max"` as the Relay-canonical highest effort; provider drivers map to native values (e.g. Codex `"xhigh"`); unknown strings pass through
 - Mid-session model switches emit a `model_switched` system event (divider in chat + timeline). It's recorded at **message-dispatch time** (`recordModelSwitchOnDispatch`), not when the user picks a model in the UI — only when the resolved model differs from the previous turn's (`instance.lastTurnModel`). So toggling the picker without sending, or switching away and back before sending, produces no divider; the divider always sits directly above the first turn the new model ran. Relay-level events like this never appear in provider transcripts, so they're persisted in the `session_events` table and re-merged into history by `mergeSessionEvents()` on every hydrate/getHistory. `lastTurnModel` is in-memory only, so the first send after a server restart re-establishes the baseline without a divider
 

--- a/app/src/components/chat/input-area/provider-model-picker.tsx
+++ b/app/src/components/chat/input-area/provider-model-picker.tsx
@@ -175,6 +175,7 @@ const RUNTIME_MODE_ORDER: ProviderRuntimeMode[] = [
   "approval-required",
   "full-access",
   "auto",
+  "writes-only",
   "plan",
 ];
 
@@ -182,6 +183,7 @@ const RUNTIME_MODE_ICON: Record<ProviderRuntimeMode, typeof LockIcon> = {
   "approval-required": LockIcon,
   "full-access": LockOpenIcon,
   auto: ShieldCheckIcon,
+  "writes-only": LockOpenIcon,
   plan: MapIcon,
 };
 

--- a/app/src/hooks/use-provider-models.test.ts
+++ b/app/src/hooks/use-provider-models.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderModelsResponse } from "@shared/types";
+import { getDefaultProviderCapabilities } from "@shared/provider-catalog";
+import { providerModelsRefetchInterval } from "./use-provider-models";
+
+function response(withAdvisory: boolean): ProviderModelsResponse {
+  const capabilities = getDefaultProviderCapabilities("codex");
+  return {
+    provider: "codex",
+    models: [],
+    capabilities: withAdvisory
+      ? {
+          ...capabilities,
+          versionAdvisory: {
+            status: "current",
+            currentVersion: "0.144.0",
+            latestVersion: "0.144.0",
+            packageName: "@openai/codex",
+            updateCommand: null,
+            installMethod: "manual",
+            checkedAt: "2026-07-16T00:00:00.000Z",
+          },
+        }
+      : capabilities,
+  };
+}
+
+describe("providerModelsRefetchInterval", () => {
+  it("polls during bootstrap until provider version capabilities resolve", () => {
+    expect(providerModelsRefetchInterval(undefined)).toBe(5_000);
+    expect(providerModelsRefetchInterval(response(false))).toBe(5_000);
+  });
+
+  it("stops polling after the version advisory arrives", () => {
+    expect(providerModelsRefetchInterval(response(true))).toBe(false);
+  });
+});

--- a/app/src/hooks/use-provider-models.ts
+++ b/app/src/hooks/use-provider-models.ts
@@ -1,12 +1,22 @@
 import { useState } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import type { ProviderCapabilities, ProviderKind, ProviderModelOption } from "@shared/types";
+import type {
+  ProviderCapabilities,
+  ProviderKind,
+  ProviderModelOption,
+  ProviderModelsResponse,
+} from "@shared/types";
 import { getDefaultProviderCapabilities } from "@shared/provider-catalog";
 import { fetchProviderModels } from "@/lib/api";
 
 // Discovered models change rarely; cache for a minute so opening the picker for
 // several providers doesn't refire discovery on every render/mount.
 const PROVIDER_MODELS_STALE_TIME = 60_000;
+const PROVIDER_MODELS_BOOTSTRAP_REFETCH_INTERVAL = 5_000;
+
+export function providerModelsRefetchInterval(data: ProviderModelsResponse | undefined) {
+  return data?.capabilities.versionAdvisory ? false : PROVIDER_MODELS_BOOTSTRAP_REFETCH_INTERVAL;
+}
 
 export function useProviderModels(provider?: ProviderKind) {
   const [showModelMenu, setShowModelMenu] = useState(false);
@@ -17,6 +27,7 @@ export function useProviderModels(provider?: ProviderKind) {
     queryFn: () => fetchProviderModels(provider!),
     enabled: !!provider,
     staleTime: PROVIDER_MODELS_STALE_TIME,
+    refetchInterval: (query) => providerModelsRefetchInterval(query.state.data),
   });
 
   const availableProviderModels: ProviderModelOption[] =

--- a/server/core/index.ts
+++ b/server/core/index.ts
@@ -41,11 +41,13 @@ export {
   resolveProviderDefaultModelOption,
 } from "#core/provider-catalog.js";
 export {
+  buildEffectiveProviderCapabilities,
   getCachedVersionAdvisory,
   getProviderCapabilities,
   getProviderDriver,
   getRegisteredProviders,
   inferClaudeModelIdFromSdkInfo,
+  isClaudeAutoModeAvailable,
   isProviderAvailable,
   listAvailableProviders,
   refreshProviderVersionAdvisories,

--- a/server/core/instance-manager.ts
+++ b/server/core/instance-manager.ts
@@ -8457,6 +8457,7 @@ export class InstanceManager extends EventEmitter {
   async setRuntimeMode(id: string, mode: ProviderRuntimeMode): Promise<boolean> {
     return this.enqueueInstanceMutation(id, async (instance) => {
       if (instance.info.external || !instance.process) return false;
+      if (!getProviderCapabilities(instance.info.provider).runtimeModes?.[mode]) return false;
 
       instance.info.runtimeMode = mode;
       instance.process.setRuntimeMode(mode);

--- a/server/core/provider-catalog.ts
+++ b/server/core/provider-catalog.ts
@@ -242,6 +242,10 @@ export const DEFAULT_PROVIDER_CAPABILITIES: Record<ProviderKind, ProviderCapabil
         label: "Full access",
         description: "Run commands directly without sandboxing",
       },
+      "writes-only": {
+        label: "Writes only",
+        description: "Auto-allow read operations; only prompt for write operations",
+      },
       plan: {
         label: "Plan",
         description: "Stay in planning mode for this chat",

--- a/server/core/provider-catalog.ts
+++ b/server/core/provider-catalog.ts
@@ -243,7 +243,7 @@ export const DEFAULT_PROVIDER_CAPABILITIES: Record<ProviderKind, ProviderCapabil
         description: "Run commands directly without sandboxing",
       },
       "writes-only": {
-        label: "Writes only",
+        label: "Approve writes",
         description: "Auto-allow read operations; only prompt for write operations",
       },
       plan: {

--- a/server/core/provider-registry.ts
+++ b/server/core/provider-registry.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -30,7 +31,11 @@ import type {
 import { createSdkSessionSync, getSdkDiscoveredModels } from "#core/providers/claude-sdk.js";
 import { findClaudeBinary, isClaudeInstalled } from "#core/providers/claude-cli.js";
 import { findCodexBinary, isCodexInstalled } from "#core/providers/codex-cli.js";
-import { buildVersionAdvisory, executeUpdateCommand } from "#core/provider-versions.js";
+import {
+  buildVersionAdvisory,
+  compareSemver,
+  executeUpdateCommand,
+} from "#core/provider-versions.js";
 import type { ProviderVersionAdvisory } from "#core/types.js";
 import { discoverCodexModels, getCachedCodexModels } from "#core/providers/codex-models.js";
 import { CodexAppServerSession } from "#core/providers/codex-app-server.js";
@@ -1069,9 +1074,70 @@ export function getProviderCapabilities(provider: ProviderKind): ProviderCapabil
   // one model onto another through provider-level aggregation.
   const base = getProviderDriver(provider).capabilities;
   const advisory = versionAdvisoryCache.get(provider);
+  const effective = buildEffectiveProviderCapabilities(provider, base, advisory);
   // Always include a versionAdvisory if we have one cached; the UI uses its
   // presence (vs absence) to know whether the probe has completed yet.
-  return advisory ? { ...base, versionAdvisory: advisory } : base;
+  return advisory ? { ...effective, versionAdvisory: advisory } : effective;
+}
+
+const CODEX_WRITES_MIN_VERSION = "0.144.0";
+
+function isTruthyEnvironmentValue(value: string | undefined): boolean {
+  return value != null && ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function readClaudeUserSettings(): Record<string, unknown> | null {
+  const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isClaudeAutoModeAvailable(
+  env: NodeJS.ProcessEnv = process.env,
+  userSettings: Record<string, unknown> | null = readClaudeUserSettings(),
+): boolean {
+  if (userSettings?.disableAutoMode === "disable") return false;
+  return [
+    "CLAUDE_CODE_ENABLE_AUTO_MODE",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+  ].some((name) => isTruthyEnvironmentValue(env[name]));
+}
+
+export function buildEffectiveProviderCapabilities(
+  provider: ProviderKind,
+  base: ProviderCapabilities,
+  advisory?: ProviderVersionAdvisory,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    claudeUserSettings?: Record<string, unknown> | null;
+  } = {},
+): ProviderCapabilities {
+  const runtimeModes = { ...base.runtimeModes };
+
+  if (provider === "codex") {
+    const version = advisory?.currentVersion;
+    const isValidVersion = !!version && /^v?\d+(?:\.\d+){0,2}(?:[-+]|$)/i.test(version);
+    if (!isValidVersion || compareSemver(version, CODEX_WRITES_MIN_VERSION) < 0) {
+      delete runtimeModes["writes-only"];
+    }
+  }
+
+  if (
+    provider === "claude" &&
+    !isClaudeAutoModeAvailable(options.env, options.claudeUserSettings)
+  ) {
+    delete runtimeModes.auto;
+  }
+
+  return { ...base, runtimeModes };
 }
 
 export function createManagedProviderSession(
@@ -1090,7 +1156,11 @@ export function createManagedProviderSession(
           : getProviderDisplayName(provider);
     throw new Error(`${binary} is not available on this machine`);
   }
-  return driver.createSession(config, options, context);
+  const requestedMode = options?.runtimeMode ?? config.defaultRuntimeMode;
+  const runtimeMode = getProviderCapabilities(provider).runtimeModes?.[requestedMode]
+    ? requestedMode
+    : "approval-required";
+  return driver.createSession(config, { ...options, runtimeMode }, context);
 }
 
 export function resolveManagedTranscriptPathForProvider(

--- a/server/core/providers/codex-app-server.ts
+++ b/server/core/providers/codex-app-server.ts
@@ -951,7 +951,12 @@ export class CodexAppServerSession extends EventEmitter implements ProviderSessi
   }
 
   setRuntimeMode(mode: ProviderRuntimeMode): void {
-    if (mode !== "approval-required" && mode !== "full-access" && mode !== "plan") {
+    if (
+      mode !== "approval-required" &&
+      mode !== "full-access" &&
+      mode !== "plan" &&
+      mode !== "writes-only"
+    ) {
       this.logger.warn(`[CodexAppServer] Unknown runtime mode: ${mode}`);
       return;
     }
@@ -2517,10 +2522,11 @@ export class CodexAppServerSession extends EventEmitter implements ProviderSessi
 
   private resolveApprovalPolicy(): string {
     if (this._runtimeMode === "full-access") return "never";
+    if (this._runtimeMode === "writes-only") return "writes";
     // Plan and approval-required both use the same approval policy: let the
     // model decide when to escalate for approval. ("untrusted" would ask for
     // everything; "never" is reserved for full-access.) Note: Codex dropped the
-    // old "on-failure" variant; valid values are untrusted/on-request/granular/never.
+    // old "on-failure" variant; valid values are untrusted/on-request/granular/never/writes.
     return "on-request";
   }
 

--- a/server/core/types.ts
+++ b/server/core/types.ts
@@ -142,7 +142,12 @@ export interface ResolvedSuggestion {
 
 export type InstanceStatus = "idle" | "processing" | "error" | "stopped";
 export type ProviderKind = "claude" | "codex" | "gemini";
-export type ProviderRuntimeMode = "approval-required" | "full-access" | "plan" | "auto";
+export type ProviderRuntimeMode =
+  | "approval-required"
+  | "full-access"
+  | "plan"
+  | "auto"
+  | "writes-only";
 
 /**
  * Canonical cross-provider reasoning effort level.

--- a/test/claude-sdk.test.js
+++ b/test/claude-sdk.test.js
@@ -222,6 +222,22 @@ describe("ClaudeSdkSession", () => {
       session.close();
     });
 
+    it("passes auto permission mode when runtimeMode is 'auto'", async () => {
+      let capturedOptions;
+      const fakeQuery = new FakeQuery();
+      const session = await createSdkSession({
+        cwd: "/test",
+        runtimeMode: "auto",
+        logger: noopLogger,
+        queryFn: ({ _prompt, options }) => {
+          capturedOptions = options;
+          return fakeQuery;
+        },
+      });
+      assert.equal(capturedOptions.permissionMode, "auto");
+      session.close();
+    });
+
     it("sets canUseTool when runtimeMode defaults to approval-required", async () => {
       let capturedOptions;
       const fakeQuery = new FakeQuery();
@@ -972,7 +988,7 @@ describe("ClaudeSdkSession", () => {
   });
 
   describe("permissions", () => {
-    it("setRuntimeMode forwards plan + bypassPermissions modes to the SDK", async () => {
+    it("setRuntimeMode forwards supported permission modes to the SDK", async () => {
       const harness = makeHarness();
       const session = await createTestSession(harness, {
         runtimeMode: "full-access",
@@ -980,8 +996,13 @@ describe("ClaudeSdkSession", () => {
 
       session.setRuntimeMode("plan");
       session.setRuntimeMode("full-access");
+      session.setRuntimeMode("auto");
 
-      assert.deepEqual(harness.fakeQuery.setPermissionModeCalls, ["plan", "bypassPermissions"]);
+      assert.deepEqual(harness.fakeQuery.setPermissionModeCalls, [
+        "plan",
+        "bypassPermissions",
+        "auto",
+      ]);
       session.close();
     });
 

--- a/test/codex-app-server.test.js
+++ b/test/codex-app-server.test.js
@@ -660,6 +660,27 @@ describe("CodexAppServerSession", () => {
     session.close();
   });
 
+  it("writes-only runtime mode requests approval only for writes", async () => {
+    const harness = createHarness();
+    const session = new CodexAppServerSession({
+      cwd: "/tmp/project",
+      runtimeMode: "writes-only",
+      logger: noopLogger,
+      spawnProcess: harness.spawnProcess,
+      codexPath: "codex",
+    });
+
+    session.send("inspect this project");
+    const child = harness.children[0];
+    autoRespond(child);
+    await tick(50);
+
+    const msgs = child.getStdinMessages();
+    assert.equal(msgs.find((m) => m.method === "thread/start").params.approvalPolicy, "writes");
+    assert.equal(msgs.find((m) => m.method === "turn/start").params.approvalPolicy, "writes");
+    session.close();
+  });
+
   it("resumes an existing thread when resumeSessionId is provided", async () => {
     const harness = createHarness();
     const session = new CodexAppServerSession({

--- a/test/provider-registry.test.js
+++ b/test/provider-registry.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildEffectiveProviderCapabilities,
   getProviderDriver,
   getProviderCapabilities,
   getRegisteredProviders,
@@ -33,6 +34,54 @@ function makeContext() {
 }
 
 describe("provider registry", () => {
+  it("only exposes Codex writes mode for CLI 0.144.0 or newer", () => {
+    const base = getProviderDriver("codex").capabilities;
+    const advisory = (currentVersion) => ({
+      status: "current",
+      currentVersion,
+      latestVersion: currentVersion,
+      packageName: "@openai/codex",
+      updateCommand: null,
+      installMethod: "manual",
+      checkedAt: new Date().toISOString(),
+    });
+
+    assert.equal(
+      buildEffectiveProviderCapabilities("codex", base, advisory("0.143.9")).runtimeModes?.[
+        "writes-only"
+      ],
+      undefined,
+    );
+    assert.ok(
+      buildEffectiveProviderCapabilities("codex", base, advisory("0.144.0")).runtimeModes?.[
+        "writes-only"
+      ],
+    );
+    assert.ok(
+      buildEffectiveProviderCapabilities("codex", base, advisory("0.145.0-alpha.1")).runtimeModes?.[
+        "writes-only"
+      ],
+    );
+  });
+
+  it("only exposes Claude auto mode for eligible, enabled environments", () => {
+    const base = getProviderDriver("claude").capabilities;
+    const capabilities = (env, settings = null) =>
+      buildEffectiveProviderCapabilities("claude", base, undefined, {
+        env,
+        claudeUserSettings: settings,
+      });
+
+    assert.equal(capabilities({}).runtimeModes?.auto, undefined);
+    assert.ok(capabilities({ CLAUDE_CODE_USE_BEDROCK: "1" }).runtimeModes?.auto);
+    assert.ok(capabilities({ CLAUDE_CODE_ENABLE_AUTO_MODE: "true" }).runtimeModes?.auto);
+    assert.equal(
+      capabilities({ CLAUDE_CODE_USE_VERTEX: "1" }, { disableAutoMode: "disable" }).runtimeModes
+        ?.auto,
+      undefined,
+    );
+  });
+
   it("registers drivers for all known provider kinds", () => {
     assert.deepEqual(getRegisteredProviders().sort(), ["claude", "codex", "gemini"]);
   });


### PR DESCRIPTION
## What this does

Adds Codex's `writes` approval policy as Relay's **Approve writes** runtime mode. Read-only operations can proceed automatically while write operations still require approval.

This PR also hardens provider runtime-mode compatibility after Claude Auto mode landed on `main`:

- Codex `writes-only` is advertised only when the installed CLI is v0.144.0 or newer.
- Claude `auto` is advertised only for Bedrock, Vertex, Foundry, or explicit `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in, and is hidden when user settings contain `disableAutoMode: "disable"`.
- Unsupported or stale runtime-mode changes are rejected, and restored unsupported modes safely fall back to `approval-required`.
- Provider-model metadata polls briefly during startup until the version probe resolves, so version-gated controls appear without requiring a reload or Chat remount.

The UI remains provider-agnostic: it renders only the modes declared by effective `ProviderCapabilities.runtimeModes`.

## Main changes

- Adds `writes-only` to `ProviderRuntimeMode` and the shared runtime-mode picker.
- Maps `writes-only` to Codex `approvalPolicy: "writes"`.
- Filters effective capabilities in `provider-registry.ts` using the installed Codex version and Claude environment/settings.
- Adds server-side enforcement for session creation and mid-session mode changes.
- Adds provider-driver, capability-gating, and provider-model bootstrap-refresh tests.
- Marks tasks `d7f03b28` and `e2a81c94` complete and updates the architecture notes.

## Verification

- `pnpm ci-check`
- Server: 891 tests passed
- App: 122 tests passed
- GitHub CI and blast-radius checks

## Upstream references

- Codex CLI v0.144.0: `writes` app approval mode
- Claude Code v2.1.207: Auto mode availability and `disableAutoMode`
