### PR TITLE
provider-watch: triage 2026-07-13 → 2026-07-20

### DIFF
--- a/.relay/changelog-watch-state.json
+++ b/.relay/changelog-watch-state.json
@@ -1,8 +1,8 @@
 {
-  "claude-code-cli": "2.1.207",
-  "claude-agent-sdk": "0.3.207",
-  "anthropic-sdk": "0.111.0",
-  "codex-cli": "0.144.3",
-  "codex-app-server": "0.144.3",
-  "lastRunAt": "2026-07-13T00:00:00.000Z"
+  "claude-code-cli": "2.1.215",
+  "claude-agent-sdk": "0.3.215",
+  "anthropic-sdk": "0.112.3",
+  "codex-cli": "0.144.6",
+  "codex-app-server": "0.144.6",
+  "lastRunAt": "2026-07-20T00:00:00.000Z"
 }

--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2405,6 +2405,58 @@
       "blockedBy": [],
       "createdAt": "2026-07-15T00:00:00.000Z",
       "updatedAt": "2026-07-16T02:01:00.000Z"
+    },
+    {
+      "id": "e4b71c9f",
+      "title": "Claude Agent SDK: verify permission-mode mapping after set_permission_mode hardening",
+      "description": "SDK 0.3.214 changed `set_permission_mode` to throw on unrecognized permission modes instead of silently accepting them. Previously, passing an unexpected value was a no-op; now it raises a visible error.\n\nRelay's `claude-sdk.ts` maps `ProviderRuntimeMode` values to Claude SDK permission modes and calls `set_permission_mode` during session init and runtime-mode switches. If any code path produces a non-canonical value (from a DB edge case, a null/undefined fallback, or an exhaustiveness gap in `resolvePermissionMode`), it will now surface as a live error instead of silent misbehavior.\n\nAudit needed:\n1. Check every call site of `set_permission_mode` in `server/core/providers/claude-sdk.ts`.\n2. Confirm all values sent are in the accepted set (`'default'`, `'acceptEdits'`, `'bypassPermissions'`, `'manual'` per the v0.3.200 alias note).\n3. Confirm the `ProviderRuntimeMode` → SDK mode mapping is exhaustive and cannot produce an unexpected string.\n4. Confirm that SDK 0.3.214+ is in the installed range before landing.\n\nScope: small (~1h audit). No behavioral change expected if the mapping is correct; this is a defensive regression check.\n\nBucket 0 — priority 1.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
+      "status": "open",
+      "priority": 1,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-0"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-20T00:00:00.000Z",
+      "updatedAt": "2026-07-20T00:00:00.000Z"
+    },
+    {
+      "id": "b3a52de8",
+      "title": "Claude Agent SDK: render interrupted assistant messages with aborted indicator",
+      "description": "SDK 0.3.214 adds `aborted: true` to assistant messages cut short by `interrupt()` (user cancelled mid-turn). Previously, partial messages were indistinguishable from complete ones in both the live stream and the JSONL transcript.\n\nTwo paths Relay should update:\n1. **Live stream** (`claude-sdk.ts`): when an assistant message arrives with `aborted: true`, propagate a flag through `SessionHistoryEntry` / `ChatMessage` so the UI can render a visual indicator (e.g. a \"Cancelled\" badge on the partial text).\n2. **JSONL replay**: the JSONL entry for the interrupted message carries `aborted: true`; parse it and set the same flag on the replayed message so history renders consistently.\n\nUI touch point: `app/src/components/chat/claude-message.tsx`. The indicator should be subtle and not disrupt normal message flow.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-2"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-20T00:00:00.000Z",
+      "updatedAt": "2026-07-20T00:00:00.000Z"
+    },
+    {
+      "id": "f8c1a047",
+      "title": "Claude Agent SDK: surface subagent_type and subagent_retry in agents sidecar",
+      "description": "SDK 0.3.214 adds two new fields to `tool_progress` events:\n- `subagent_type`: identifies what kind of subagent is running.\n- `subagent_retry`: whether this is a retry of a previously failed tool call.\n\nRelay's agents sidecar panel (see also open task `ffbc884b` for the related `blocked` field) shows live agent activity from `workflow_agent` and `tool_progress` events. These fields can enrich it:\n- Show subagent-type labels on agent rows instead of generic identifiers.\n- Show a retry indicator (badge or icon) on retried tool calls.\n\nTouch points:\n1. `claude-sdk.ts`: parse `subagent_type` and `subagent_retry` from `tool_progress` events and forward through `AgentActivity`.\n2. Agents sidecar component: render type labels and retry indicator.\n\nCoordinate with `ffbc884b` (blocked field) — consider landing together as a single sidecar-enrichment pass.\n\nScope: small (~2–3h including UI).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-2"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-20T00:00:00.000Z",
+      "updatedAt": "2026-07-20T00:00:00.000Z"
+    },
+    {
+      "id": "9d3e6b82",
+      "title": "Claude Agent SDK: store SDK-provided assistant message timestamp for live-stream accuracy",
+      "description": "SDK 0.3.211 added an ISO-8601 `timestamp` field to `SDKAssistantMessage` in the live stream. This is the moment the model completed the message, as opposed to Relay's current processed-at time (when the server received the event).\n\nRelay could:\n1. Store the model-completion timestamp on `SessionHistoryEntry` / `ChatMessage` (a new optional `modelTimestamp` field).\n2. Display it in a message footer or tooltip as a more accurate \"generated at\" time — useful for long turns where server-processing lag is noticeable.\n\nScope: small (~1–2h). Touch points: `claude-sdk.ts` (parse + forward), `ChatMessage` type (add optional `modelTimestamp`), message renderer (display).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.211",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": ["provider-watch", "claude", "bucket-2"],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-20T00:00:00.000Z",
+      "updatedAt": "2026-07-20T00:00:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
This is the **automated weekly release-notes sweep** for Claude Code CLI, Claude Agent SDK, Anthropic SDK, and Codex. Merging this PR accepts the four new to-dos filed below and moves the "last checked" marker forward to today. **It touches zero app code** — only `.relay/tasks.json` and `.relay/changelog-watch-state.json`.

Watermarks advanced: claude-code-cli 2.1.207 → 2.1.215 · claude-agent-sdk 0.3.207 → 0.3.215 · anthropic-sdk 0.111.0 → 0.112.3 · codex-cli/app-server 0.144.3 → 0.144.6.

---

## Needs attention before upgrading

**Claude Agent SDK `set_permission_mode` now errors on unknown modes (SDK 0.3.214)** — Previously, passing an unrecognized permission-mode string to the SDK was silently ignored. It now throws. Relay maps `ProviderRuntimeMode` values to Claude's native permission modes and calls `set_permission_mode` on session init and runtime-mode switches; if any code path produces a non-canonical value, it will now surface as a live error. Requires a small audit of `claude-sdk.ts` before upgrading to 0.3.214+. → task `e4b71c9f`, priority 1.

---

## To-dos filed

**Render interrupted assistant messages with an "aborted" indicator (task `b3a52de8`, priority 2).** SDK 0.3.214 adds `aborted: true` to messages cut short by `interrupt()`. Right now Relay treats a cancelled partial message the same as a completed one. Relay should propagate this flag through `SessionHistoryEntry` and the JSONL replay path so the UI can show a subtle "Cancelled" indicator — both live and in history.

**Surface `subagent_type` and `subagent_retry` in the agents sidecar (task `f8c1a047`, priority 2).** SDK 0.3.214 adds two new fields to `tool_progress` events. `subagent_type` lets Relay label agent rows with their actual type instead of a generic identifier; `subagent_retry` lets Relay show a retry badge on retried tool calls. Small change to `claude-sdk.ts` + sidecar rendering. Good candidate to land alongside the related open task `ffbc884b` (blocked field) as a single sidecar-enrichment pass.

**Store the SDK-provided assistant message timestamp (task `9d3e6b82`, priority 2).** SDK 0.3.211 adds an ISO-8601 `timestamp` to `SDKAssistantMessage` in the live stream — the moment the model finished the message, not when Relay received it. Relay could store this as an optional `modelTimestamp` on `ChatMessage` and display it as a more accurate "generated at" time, especially useful for long turns.

---

## No action needed

- **Claude Code CLI 2.1.208–2.1.215**: Security fixes (permission-rule bypass corrections, worktree symlink hardening, prompt-injection hardening on Agent tool), screen reader mode, vim remaps, `CLAUDE_CODE_PROCESS_WRAPPER` — all CLI-internal or flowing through via SDK. No Relay changes needed.
- **`EndConversation` tool** (CLI 2.1.214): New tool type; Relay's JSONL parser handles unknown tool types generically — no change needed.
- **Progress heartbeat for extended tool calls** (CLI 2.1.214): SDK-level; Relay doesn't need to handle heartbeat messages explicitly.
- **`applyFlagSettings({effortLevel})` now accepts `'max'`** (SDK 0.3.214): TypeScript type fix. Relay already uses `'max'` as its canonical highest-effort value; this aligns the SDK type with the value Relay was already passing at runtime.
- **`timedOutAfterMs` on `BashToolOutput`** (SDK 0.3.210): New field for auto-backgrounded commands; not surfaced in Relay's current tool-call display, no action needed.
- **SessionStart hook `"fork"` source** (SDK 0.3.214): Relay doesn't branch on hook source — no change needed.
- **Codex 0.144.5**: Improved dangerous-command detection — internal to Codex CLI, no Relay impact.
- **Codex 0.144.6**: Corrected context windows for GPT-5.6 Sol/Terra/Luna to 272 k tokens — Relay already reads provider-reported context windows (task `b148f169` done), so the correction flows through automatically.
- **Anthropic SDK 0.112.1–0.112.3**: Documentation updates only.

---

## Skipped — not Relay's concern

- `/fork` redesign, `/resume` session picker, `claude auto-mode reset` (CLI 2.1.212–2.1.213): CLI-internal session-management UI; Relay manages sessions at a different layer.
- Rate-limit message prefix buckets as alpha exports (SDK 0.3.211): Useful helpers but alpha-flagged and Relay already has its own rate-limit event handling.
- **Anthropic SDK MCP Tunnels** (SDK 0.112.0): Adds tunnel transport to the Messages API SDK. Claude Code CLI changelog for this period makes no mention of exposing tunnel as an MCP transport option in the CLI's `--add-mcp-server` flow, so there is no `ProviderCapabilities.mcp.management.transports` change to make today. Watch for CLI adoption in future runs.
- Codex 0.145.0-alpha series: Pre-releases with no documented protocol changes; skip until stable.

---

> Note: the `provider-watch` label could not be applied automatically (no label-creation tool available in this environment). Apply it manually: `gh label create provider-watch --color BFD4F2 || true`, then add it to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UhqqdRE47Fuu2gswbZbLD)_