### PR TITLE
feat: render interrupted assistant messages with aborted indicator

### DIFF
--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2345,19 +2345,19 @@
       "id": "b3a52de8",
       "title": "Claude Agent SDK: render interrupted assistant messages with aborted indicator",
       "description": "SDK 0.3.214 adds `aborted: true` to assistant messages cut short by `interrupt()` (user cancelled mid-turn). Previously, partial messages were indistinguishable from complete ones in both the live stream and the JSONL transcript.\n\nTwo paths Relay should update:\n1. **Live stream** (`claude-sdk.ts`): when an assistant message arrives with `aborted: true`, propagate a flag through `SessionHistoryEntry` / `ChatMessage` so the UI can render a visual indicator (e.g. a \"Cancelled\" badge on the partial text).\n2. **JSONL replay**: the JSONL entry for the interrupted message carries `aborted: true`; parse it and set the same flag on the replayed message so history renders consistently.\n\nUI touch point: `app/src/components/chat/claude-message.tsx`. The indicator should be subtle and not disrupt normal message flow.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
-      "status": "open",
+      "status": "in_progress",
       "priority": 2,
       "type": "task",
       "tags": ["provider-watch", "claude", "bucket-2"],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
-      "updatedAt": "2026-07-20T00:00:00.000Z"
+      "updatedAt": "2026-07-29T00:00:00.000Z"
     },
     {
       "id": "f8c1a047",
       "title": "Claude Agent SDK: surface subagent_type and subagent_retry in agents sidecar",
-      "description": "SDK 0.3.214 adds two new fields to `tool_progress` events:\n- `subagent_type`: identifies what kind of subagent is running.\n- `subagent_retry`: whether this is a retry of a previously failed tool call.\n\nRelay's agents sidecar panel (see also open task `ffbc884b` for the related `blocked` field) shows live agent activity from `workflow_agent` and `tool_progress` events. These fields can enrich it:\n- Show subagent-type labels on agent rows instead of generic identifiers.\n- Show a retry indicator (badge or icon) on retried tool calls.\n\nTouch points:\n1. `claude-sdk.ts`: parse `subagent_type` and `subagent_retry` from `tool_progress` events and forward through `AgentActivity`.\n2. Agents sidecar component: render type labels and retry indicator.\n\nCoordinate with `ffbc884b` (blocked field) — consider landing together as a single sidecar-enrichment pass.\n\nScope: small (~2–3h including UI).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
+      "description": "SDK 0.3.214 adds two new fields to `tool_progress` events:\n- `subagent_type`: identifies what kind of subagent is running.\n- `subagent_retry`: whether this is a retry of a previously failed tool call.\n\nRelay's agents sidecar panel (see also open task `ffbc884b` for the related `blocked` field) shows live agent activity from `workflow_agent` and `tool_progress` events. These fields can enrich it:\n- Show subagent-type labels on agent rows instead of generic identifiers.\n- Show a retry indicator (badge or icon) on retried tool calls.\n\nTouch points:\n1. `claude-sdk.ts`: parse `subagent_type` and `subagent_retry` from `tool_progress` events and forward through `AgentActivity`.\n2. Agents sidecar component: render type labels and retry indicator.\n\nCoordinate with `ffbc884b` (blocked field) — consider landing together as a single sidecar-enrichment pass.\n\nScope: small (~2–3h including UI).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214\n\n---\n**Kicked back 2026-07-29**: Not mechanical. `SidecarTab` union in `app/src/stores/sidecar-store.ts` has no `\"agents\"` tab — the agents sidecar view does not exist as a discrete tab. Same blocker as `ffbc884b`. This task needs a design decision on where/how to surface subagent-type and retry information before any implementation can proceed.",
       "status": "open",
       "priority": 2,
       "type": "task",
@@ -2365,7 +2365,7 @@
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
-      "updatedAt": "2026-07-20T00:00:00.000Z"
+      "updatedAt": "2026-07-29T00:00:00.000Z"
     },
     {
       "id": "9d3e6b82",

--- a/app/src/components/chat/agent-message.tsx
+++ b/app/src/components/chat/agent-message.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { MarkdownContent } from "./markdown-content";
 import { MessageHoverToolbar } from "./message-hover-toolbar";
 import { formatTimestamp } from "../../lib/utils";
-import { CornerDownLeft, GitBranchPlus } from "lucide-react";
+import { CornerDownLeft, GitBranchPlus, OctagonX } from "lucide-react";
 import { useMessageRelay } from "@/components/chat/message-relay-context";
 import { Textarea } from "@/components/ui/input";
 import { useTextSelection } from "@/hooks/use-text-selection";
@@ -13,6 +13,7 @@ interface AgentMessageProps {
   text: string;
   timestamp?: number;
   anchorIndex?: number;
+  aborted?: boolean;
 }
 
 function SelectionReplyPopover({
@@ -137,7 +138,7 @@ function SelectionReplyPopover({
   );
 }
 
-export function AgentMessage({ text, timestamp, anchorIndex }: AgentMessageProps) {
+export function AgentMessage({ text, timestamp, anchorIndex, aborted }: AgentMessageProps) {
   const relay = useMessageRelay();
   const contentRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -255,8 +256,18 @@ export function AgentMessage({ text, timestamp, anchorIndex }: AgentMessageProps
         />
       )}
 
-      {timestamp && (
-        <span className="px-1 text-[10px] text-muted/45">{formatTimestamp(timestamp)}</span>
+      {(timestamp || aborted) && (
+        <div className="flex items-center gap-2 px-1">
+          {aborted && (
+            <span className="inline-flex items-center gap-1 text-[10px] text-muted/60">
+              <OctagonX size={10} />
+              Cancelled
+            </span>
+          )}
+          {timestamp && (
+            <span className="text-[10px] text-muted/45">{formatTimestamp(timestamp)}</span>
+          )}
+        </div>
       )}
 
       <AnimatePresence>

--- a/app/src/components/chat/build-rows.ts
+++ b/app/src/components/chat/build-rows.ts
@@ -163,6 +163,7 @@ export function buildRows(items: ChatItem[]): RenderRow[] {
             text: item.text,
             timestamp: item.timestamp,
             isLast: i === lastAssistantIndex,
+            aborted: item.aborted,
           });
           break;
         case "system":

--- a/app/src/components/chat/message-list.tsx
+++ b/app/src/components/chat/message-list.tsx
@@ -419,6 +419,7 @@ export function MessageList({
             text={row.text}
             timestamp={row.timestamp}
             anchorIndex={Number.isFinite(origIdx) ? origIdx : rowIndex}
+            aborted={row.aborted}
           />
         );
       }

--- a/app/src/hooks/use-instance-messages.ts
+++ b/app/src/hooks/use-instance-messages.ts
@@ -159,6 +159,7 @@ export function replayHistoryToItems(history: HistoryEntry[]): ChatItem[] {
   let items: ChatItem[] = [];
   let assistantText = "";
   let assistantTimestamp: number | undefined;
+  let assistantAborted: boolean | undefined;
   let currentActivities: MergedActivity[] = [];
 
   const flushActivities = () => {
@@ -168,11 +169,17 @@ export function replayHistoryToItems(history: HistoryEntry[]): ChatItem[] {
     }
   };
 
-  const flushAssistant = () => {
+  const flushAssistant = (aborted?: boolean) => {
     if (assistantText) {
-      items.push({ kind: "assistant", text: assistantText, timestamp: assistantTimestamp });
+      items.push({
+        kind: "assistant",
+        text: assistantText,
+        timestamp: assistantTimestamp,
+        aborted: aborted || assistantAborted || undefined,
+      });
       assistantText = "";
       assistantTimestamp = undefined;
+      assistantAborted = undefined;
     }
   };
 
@@ -191,7 +198,7 @@ export function replayHistoryToItems(history: HistoryEntry[]): ChatItem[] {
         }
         if (msg.isWaiting) {
           flushActivities();
-          flushAssistant();
+          flushAssistant(msg.aborted);
         }
         break;
       case "user": {
@@ -345,6 +352,7 @@ type Action =
       text: string;
       isWaiting: boolean;
       thinking?: string;
+      aborted?: boolean;
       eventSequence?: number;
     }
   | { type: "activity"; message: ActivityMessage }
@@ -911,6 +919,7 @@ function actionToHistoryEntry(action: Action): HistoryEntry | null {
           text: action.text,
           isWaiting: action.isWaiting,
           thinking: action.thinking,
+          aborted: action.aborted,
         } as ServerMessage,
       };
     case "user":
@@ -1023,6 +1032,7 @@ export function useInstanceMessages() {
               text: message.text,
               isWaiting: message.isWaiting,
               thinking: message.thinking,
+              aborted: message.aborted,
               eventSequence: message.eventSequence,
             });
           }

--- a/app/src/lib/chat-types.ts
+++ b/app/src/lib/chat-types.ts
@@ -41,6 +41,8 @@ export interface AssistantChatItem {
   kind: "assistant";
   text: string;
   timestamp?: number;
+  /** True when the turn was cut short by a user interrupt before completion. */
+  aborted?: boolean;
 }
 
 export interface SystemChatItem {
@@ -107,6 +109,8 @@ export interface AssistantRow {
   text: string;
   timestamp?: number;
   isLast: boolean;
+  /** True when the turn was cut short by a user interrupt before completion. */
+  aborted?: boolean;
 }
 
 export interface SystemRow {

--- a/server/core/instance-manager.ts
+++ b/server/core/instance-manager.ts
@@ -5587,6 +5587,8 @@ export class InstanceManager extends EventEmitter {
       subtype?: string;
       cwd?: string;
       timestamp?: string;
+      /** Set on SDKAssistantMessage when the turn was cut short by an interrupt. */
+      aborted?: boolean;
       data?: Record<string, unknown>;
       message?: {
         role?: string;
@@ -5650,7 +5652,7 @@ export class InstanceManager extends EventEmitter {
       return this.convertUserEntry(entry.message.content, timestamp, ctx);
     }
     if (entry.type === "assistant" && entry.message?.content) {
-      return this.convertAssistantEntry(entry.message, timestamp, ctx);
+      return this.convertAssistantEntry(entry.message, timestamp, ctx, entry.aborted);
     }
     if (entry.type === "progress" && entry.data) {
       return this.convertProgressEntry(entry.data, timestamp);
@@ -5812,6 +5814,7 @@ export class InstanceManager extends EventEmitter {
       stats?: SessionStats;
       cwd?: string;
     },
+    aborted?: boolean,
   ): HistoryEntry[] {
     const results: HistoryEntry[] = [];
     const content = message.content;
@@ -5863,10 +5866,15 @@ export class InstanceManager extends EventEmitter {
         });
       }
 
-      // Mark end of assistant turn
+      // Mark end of assistant turn; carry aborted flag when the turn was interrupted
       results.push({
         timestamp,
-        message: { type: "output", text: "", isWaiting: true } as OutputMessage,
+        message: {
+          type: "output",
+          text: "",
+          isWaiting: true,
+          aborted: aborted || undefined,
+        } as OutputMessage,
       });
     }
 

--- a/server/core/providers/claude-sdk.ts
+++ b/server/core/providers/claude-sdk.ts
@@ -718,6 +718,8 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
   private pendingTools = new Map<string, string>();
   /** Raw assistant message for attaching to emitted events */
   private _lastRawAssistantMsg: Record<string, unknown> | null = null;
+  /** True when the last assistant message carried aborted:true (interrupt before stream completed). */
+  private _lastMsgAborted = false;
 
   private logger: CoreConfig["logger"];
   private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -1318,6 +1320,7 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
     if (this._isResumeReplay) return;
 
     this._lastRawAssistantMsg = msg;
+    this._lastMsgAborted = msg.aborted === true;
     const message = msg.message as
       | {
           content?: Array<{
@@ -2061,10 +2064,13 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
     // Refresh plan rate-limit utilization after each completed turn
     // (throttled) — live events rarely carry a percentage for the 5h window.
     this.refreshUsageRateLimits();
+    const aborted = this._lastMsgAborted || undefined;
+    this._lastMsgAborted = false;
     const done: OutputMessage = {
       type: "output",
       text: "",
       isWaiting: true,
+      aborted,
       raw: this._lastRawAssistantMsg ?? undefined,
     };
     this._lastRawAssistantMsg = null;

--- a/server/core/types.ts
+++ b/server/core/types.ts
@@ -882,6 +882,8 @@ export interface OutputMessage {
   thinking?: string;
   instanceId?: string;
   eventSequence?: number;
+  /** True when this turn was cut short by a user interrupt before completion. */
+  aborted?: boolean;
   /** Raw SDK/provider message for debug display. */
   raw?: unknown;
 }


### PR DESCRIPTION
## What

Propagates `SDKAssistantMessage.aborted` (added in claude-agent-sdk v0.3.214) through the full data path so turns cut short by a user interrupt are visually distinct from complete responses.

## Why

Before this change, partial assistant messages from interrupted turns were indistinguishable from complete ones — no visual signal that the model was mid-response when the user cancelled.

## Changes

**Server**
- `server/core/types.ts`: add `aborted?: boolean` to `OutputMessage`
- `server/core/providers/claude-sdk.ts`: capture `msg.aborted` in `handleAssistant()`, forward it on the `OutputMessage` emitted by `finishTurn()`
- `server/core/instance-manager.ts`: parse `aborted` from JSONL entries and thread it through `convertAssistantEntry()` so history replay is consistent with live stream

**Client**
- `app/src/lib/chat-types.ts`: add `aborted?: boolean` to `AssistantChatItem` and `AssistantRow`
- `app/src/hooks/use-instance-messages.ts`: thread `aborted` through WS dispatch → `actionToHistoryEntry` → `flushAssistant()` in `replayHistoryToItems`
- `app/src/components/chat/build-rows.ts`: pass `aborted` when building `AssistantRow`
- `app/src/components/chat/message-list.tsx`: pass `aborted={row.aborted}` to `<AgentMessage>`
- `app/src/components/chat/agent-message.tsx`: accept `aborted` prop; render a subtle "Cancelled" badge (OctagonX icon) alongside the timestamp when `aborted` is true

## Behaviour

- Live stream: `finishTurn()` sets `aborted` only when the SDK assistant message carries `aborted: true`; cleared each turn so normal completions are unaffected.
- JSONL replay: same `aborted` flag from the transcript entry is preserved, so reopening a chat with interrupted turns renders correctly.
- The badge is text-muted/60 with a 10px icon — visible but not alarming.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGxYva9P1aWCXb2TCacxiR)_