### PR TITLE
feat: store SDK-provided assistant message timestamp for accuracy

### DIFF
--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -2449,14 +2449,14 @@
       "id": "9d3e6b82",
       "title": "Claude Agent SDK: store SDK-provided assistant message timestamp for live-stream accuracy",
       "description": "SDK 0.3.211 added an ISO-8601 `timestamp` field to `SDKAssistantMessage` in the live stream. This is the moment the model completed the message, as opposed to Relay's current processed-at time (when the server received the event).\n\nRelay could:\n1. Store the model-completion timestamp on `SessionHistoryEntry` / `ChatMessage` (a new optional `modelTimestamp` field).\n2. Display it in a message footer or tooltip as a more accurate \"generated at\" time — useful for long turns where server-processing lag is noticeable.\n\nScope: small (~1–2h). Touch points: `claude-sdk.ts` (parse + forward), `ChatMessage` type (add optional `modelTimestamp`), message renderer (display).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.211",
-      "status": "open",
+      "status": "in_progress",
       "priority": 2,
       "type": "task",
       "tags": ["provider-watch", "claude", "bucket-2"],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
-      "updatedAt": "2026-07-20T00:00:00.000Z"
+      "updatedAt": "2026-07-29T00:00:00.000Z"
     }
   ]
 }

--- a/app/src/hooks/use-instance-messages.ts
+++ b/app/src/hooks/use-instance-messages.ts
@@ -191,6 +191,7 @@ export function replayHistoryToItems(history: HistoryEntry[]): ChatItem[] {
         }
         if (msg.isWaiting) {
           flushActivities();
+          if (msg.modelTimestamp && assistantText) assistantTimestamp = msg.modelTimestamp;
           flushAssistant();
         }
         break;
@@ -345,6 +346,7 @@ type Action =
       text: string;
       isWaiting: boolean;
       thinking?: string;
+      modelTimestamp?: number;
       eventSequence?: number;
     }
   | { type: "activity"; message: ActivityMessage }
@@ -911,6 +913,7 @@ function actionToHistoryEntry(action: Action): HistoryEntry | null {
           text: action.text,
           isWaiting: action.isWaiting,
           thinking: action.thinking,
+          modelTimestamp: action.modelTimestamp,
         } as ServerMessage,
       };
     case "user":
@@ -1023,6 +1026,7 @@ export function useInstanceMessages() {
               text: message.text,
               isWaiting: message.isWaiting,
               thinking: message.thinking,
+              modelTimestamp: message.modelTimestamp,
               eventSequence: message.eventSequence,
             });
           }

--- a/server/core/instance-manager.ts
+++ b/server/core/instance-manager.ts
@@ -5785,6 +5785,8 @@ export class InstanceManager extends EventEmitter {
   private convertAssistantEntry(
     message: {
       model?: string;
+      /** ISO-8601 model-completion time from SDKAssistantMessage.timestamp */
+      timestamp?: string;
       usage?: {
         input_tokens?: number;
         output_tokens?: number;
@@ -5818,6 +5820,7 @@ export class InstanceManager extends EventEmitter {
   ): HistoryEntry[] {
     const results: HistoryEntry[] = [];
     const content = message.content;
+    const modelTimestamp = message.timestamp ? new Date(message.timestamp).getTime() : undefined;
     if (Array.isArray(content)) {
       let textParts: string[] = [];
 
@@ -5869,7 +5872,7 @@ export class InstanceManager extends EventEmitter {
       // Mark end of assistant turn
       results.push({
         timestamp,
-        message: { type: "output", text: "", isWaiting: true } as OutputMessage,
+        message: { type: "output", text: "", isWaiting: true, modelTimestamp } as OutputMessage,
       });
     }
 

--- a/server/core/providers/claude-sdk.ts
+++ b/server/core/providers/claude-sdk.ts
@@ -718,6 +718,8 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
   private pendingTools = new Map<string, string>();
   /** Raw assistant message for attaching to emitted events */
   private _lastRawAssistantMsg: Record<string, unknown> | null = null;
+  /** Unix ms timestamp from the SDK's model-completion event (SDKAssistantMessage.timestamp). */
+  private _lastMsgTimestamp: number | undefined;
 
   private logger: CoreConfig["logger"];
   private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -1318,6 +1320,8 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
     if (this._isResumeReplay) return;
 
     this._lastRawAssistantMsg = msg;
+    const ts = typeof msg.timestamp === "string" ? msg.timestamp : undefined;
+    this._lastMsgTimestamp = ts ? new Date(ts).getTime() : undefined;
     const message = msg.message as
       | {
           content?: Array<{
@@ -2061,10 +2065,13 @@ class ClaudeSdkSessionImpl extends EventEmitter implements ClaudeSdkSession {
     // Refresh plan rate-limit utilization after each completed turn
     // (throttled) — live events rarely carry a percentage for the 5h window.
     this.refreshUsageRateLimits();
+    const modelTimestamp = this._lastMsgTimestamp;
+    this._lastMsgTimestamp = undefined;
     const done: OutputMessage = {
       type: "output",
       text: "",
       isWaiting: true,
+      modelTimestamp,
       raw: this._lastRawAssistantMsg ?? undefined,
     };
     this._lastRawAssistantMsg = null;

--- a/server/core/types.ts
+++ b/server/core/types.ts
@@ -882,6 +882,8 @@ export interface OutputMessage {
   thinking?: string;
   instanceId?: string;
   eventSequence?: number;
+  /** Unix ms timestamp from the SDK's model-completion event — more accurate than server receive time. */
+  modelTimestamp?: number;
   /** Raw SDK/provider message for debug display. */
   raw?: unknown;
 }


### PR DESCRIPTION
## What

Propagates `SDKAssistantMessage.timestamp` (added in claude-agent-sdk v0.3.211) through the full data path so the displayed "generated at" time for assistant messages reflects when the model actually completed the response, rather than when Relay's server received and processed the event.

## Why

Relay previously used `Date.now()` as the assistant message timestamp, which can lag noticeably for long turns — the model may complete the response seconds before server-side post-processing finishes. The SDK now provides the model's own completion time, which is more accurate.

## Changes

**Server**
- `server/core/types.ts`: add `modelTimestamp?: number` to `OutputMessage`
- `server/core/providers/claude-sdk.ts`: capture `SDKAssistantMessage.timestamp` (ISO string) in `handleAssistant()`, convert to unix ms in `finishTurn()`, emit on the `isWaiting: true` OutputMessage
- `server/core/instance-manager.ts`: add `timestamp?: string` to the `convertAssistantEntry` message type, compute `modelTimestamp` from it, include in the turn-terminator HistoryEntry

**Client**
- `app/src/hooks/use-instance-messages.ts`:
  - Add `modelTimestamp?: number` to the `output` action type
  - Thread it through `handleMessage` → `dispatchAndRecord` and `actionToHistoryEntry` (stored in `HistoryEntry.message`)
  - In `replayHistoryToItems`, override `assistantTimestamp` with `msg.modelTimestamp` just before `flushAssistant()` — so the model-completion time is what `AssistantChatItem.timestamp` receives

## Behaviour

- When the SDK provides a model-completion timestamp, assistant messages display that time instead of the server receive time.
- When no SDK timestamp is available (older CLI, Codex sessions, non-SDK paths), behaviour is unchanged — `modelTimestamp` is `undefined` and the existing `Date.now()` path applies.
- The JSONL replay path is also covered: `SDKAssistantMessage.timestamp` from the JSONL entry propagates consistently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGxYva9P1aWCXb2TCacxiR)_