### PR TITLE
provider-watch: triage 2026-07-20 → 2026-08-03

### DIFF
--- a/.relay/changelog-watch-state.json
+++ b/.relay/changelog-watch-state.json
@@ -1,8 +1,8 @@
 {
-  "claude-code-cli": "2.1.215",
-  "claude-agent-sdk": "0.3.215",
-  "anthropic-sdk": "0.112.3",
-  "codex-cli": "0.144.6",
-  "codex-app-server": "0.144.6",
-  "lastRunAt": "2026-07-20T00:00:00.000Z"
+  "claude-code-cli": "2.1.220",
+  "claude-agent-sdk": "0.3.220",
+  "anthropic-sdk": "0.115.0",
+  "codex-cli": "0.146.0",
+  "codex-app-server": "0.146.0",
+  "lastRunAt": "2026-08-03T00:00:00.000Z"
 }

--- a/.relay/tasks.json
+++ b/.relay/tasks.json
@@ -17,7 +17,7 @@
     {
       "id": "3ad012d4",
       "title": "Add Gemini CLI provider",
-      "description": "Implement Gemini CLI as a first-class Relay provider using Gemini ACP, matching Claude and Codex managed-session support while preserving Relay\u2019s provider-driven architecture.",
+      "description": "Implement Gemini CLI as a first-class Relay provider using Gemini ACP, matching Claude and Codex managed-session support while preserving Relay’s provider-driven architecture.",
       "status": "open",
       "priority": 2,
       "type": "epic",
@@ -30,7 +30,7 @@
     {
       "id": "cb9777dc",
       "title": "Generalize provider runtime modes",
-      "description": "Collapsed Relay's `skipPermissions`/`planMode` booleans into a single `ProviderRuntimeMode` enum (`approval-required` | `full-access` | `plan`) across server, UI, DB, and tests. Provider drivers translate the canonical mode to their native semantics (Claude SDK `permissionMode`, Codex `approvalPolicy`+`sandbox`+`collaborationMode.mode`). UI renders a single runtime-mode picker driven by `capabilities.runtimeModes`. SQLite migration v24 backfills `runtime_mode` and drops `skip_permissions` on both `sessions` and `managed_sessions`. Richer Codex options and richer interactive request payloads were deferred \u2014 left for a follow-up.",
+      "description": "Collapsed Relay's `skipPermissions`/`planMode` booleans into a single `ProviderRuntimeMode` enum (`approval-required` | `full-access` | `plan`) across server, UI, DB, and tests. Provider drivers translate the canonical mode to their native semantics (Claude SDK `permissionMode`, Codex `approvalPolicy`+`sandbox`+`collaborationMode.mode`). UI renders a single runtime-mode picker driven by `capabilities.runtimeModes`. SQLite migration v24 backfills `runtime_mode` and drops `skip_permissions` on both `sessions` and `managed_sessions`. Richer Codex options and richer interactive request payloads were deferred — left for a follow-up.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -114,7 +114,9 @@
       "type": "bug",
       "tags": [],
       "parent": null,
-      "blockedBy": ["73adce9a"],
+      "blockedBy": [
+        "73adce9a"
+      ],
       "createdAt": "2026-03-10T20:43:05.745465-04:00",
       "updatedAt": "2026-03-10T20:57:48.954414-04:00"
     },
@@ -159,7 +161,7 @@
     },
     {
       "id": "d7dff12b",
-      "title": "Redesign sidecar panel \u2014 slide-in/floating UI",
+      "title": "Redesign sidecar panel — slide-in/floating UI",
       "description": "The sidecar panel (tasks, files, team) could be nicer. Explore options: slide-in/out animation, floating panel style, better visual treatment. Current fixed w-72 panel feels utilitarian. Make it feel more polished and less intrusive.",
       "status": "done",
       "priority": 2,
@@ -225,7 +227,7 @@
     {
       "id": "807c83ad",
       "title": "Redesign external session takeover UX in chat input area",
-      "description": "The chat input area for external (terminal-side) sessions has evolved incrementally and the current state is confusing:\n\n**Current behavior:**\n- User can type freely into the input area and press send \u2014 this triggers a takeover (converts external \u2192 managed session via --resume)\n- We recently added a confirmation popup before the takeover happens, which helps but may not be enough\n- Plan/build toggle and permission level controls are hidden entirely for external sessions\n- Model/provider picker and reasoning level are shown but grayed out / disabled\n- This creates confusion: users see a partially-functional input area and think things are broken\n\n**Problems:**\n1. The disabled controls with no explanation look like bugs, not intentional design\n2. The full composer still invites typing even though the session isn't managed yet\n3. The confirmation popup is easy to dismiss without reading\n4. There's no clear visual signal that this is an \"observe only\" state vs an active session\n\n**Possible direction:**\nReplace the entire input area for external sessions with a simpler placeholder element \u2014 e.g. a card/banner explaining that this is a terminal session being observed, with an explicit \"Take over session\" button. This makes the state obvious and eliminates the confusing half-disabled controls.\n\n**Process:**\nStart by reviewing the current external session input area code and UX, discuss the specific pain points, and ideate on the right solution before implementing. This is a UX design task first, implementation second.",
+      "description": "The chat input area for external (terminal-side) sessions has evolved incrementally and the current state is confusing:\n\n**Current behavior:**\n- User can type freely into the input area and press send — this triggers a takeover (converts external → managed session via --resume)\n- We recently added a confirmation popup before the takeover happens, which helps but may not be enough\n- Plan/build toggle and permission level controls are hidden entirely for external sessions\n- Model/provider picker and reasoning level are shown but grayed out / disabled\n- This creates confusion: users see a partially-functional input area and think things are broken\n\n**Problems:**\n1. The disabled controls with no explanation look like bugs, not intentional design\n2. The full composer still invites typing even though the session isn't managed yet\n3. The confirmation popup is easy to dismiss without reading\n4. There's no clear visual signal that this is an \"observe only\" state vs an active session\n\n**Possible direction:**\nReplace the entire input area for external sessions with a simpler placeholder element — e.g. a card/banner explaining that this is a terminal session being observed, with an explicit \"Take over session\" button. This makes the state obvious and eliminates the confusing half-disabled controls.\n\n**Process:**\nStart by reviewing the current external session input area code and UX, discuss the specific pain points, and ideate on the right solution before implementing. This is a UX design task first, implementation second.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -296,7 +298,9 @@
       "type": "task",
       "tags": [],
       "parent": "befb4eea",
-      "blockedBy": ["0a13e811"],
+      "blockedBy": [
+        "0a13e811"
+      ],
       "createdAt": "2026-03-08T16:02:59.980668-04:00",
       "updatedAt": "2026-03-12T20:30:13.336845-04:00"
     },
@@ -309,7 +313,10 @@
       "type": "task",
       "tags": [],
       "parent": "befb4eea",
-      "blockedBy": ["dd5b26bc", "0a13e811"],
+      "blockedBy": [
+        "dd5b26bc",
+        "0a13e811"
+      ],
       "createdAt": "2026-03-08T16:03:04.240735-04:00",
       "updatedAt": "2026-03-12T20:30:13.348738-04:00"
     },
@@ -329,7 +336,7 @@
     {
       "id": "0c865f2c",
       "title": "Surface provider usage status and rate limits",
-      "description": "Surface provider usage status and rate limits per provider in the UI.\n\n## Implemented (2026-04-04)\n\n### Codex\n- Full rate limit bars with `usedPercent`, `windowMinutes`, `resetAt` from `account/rateLimits/read` RPC and live `account/rateLimits/updated` events\n- Account info (plan, email) from `account/read`\n- Displayed in both sidecar (provider status section) and global settings page\n- Shared `RateLimitBar` component with `windowLabel()` helper (\"5h window\", \"Weekly\", etc.)\n\n### Claude\n- `rate_limit_event` stream events now handled (previously skipped as telemetry)\n- Accumulates windows by `rateLimitType` (`five_hour`, `seven_day`, etc.)\n- Maps to same `ProviderRateLimitStatus` shape as Codex\n- `accountInfo()` SDK call on session init \u2192 populates plan, email, org\n- Hydration on client reconnect via `ensureProviderGlobalState(\"claude\")` harvesting from active sessions\n\n### Limitations (upstream)\n- Claude SDK does not send `utilization` for `allowed` status \u2014 only `resetsAt` and window type. Usage percentage only available during `allowed_warning` or `rejected`\n- `seven_day` window events only emitted when near/at the weekly limit\n- No polling API \u2014 data only arrives when a session is active and turns fire\n- Rate limit data lost on server restart (no persistence); re-populated after first turn",
+      "description": "Surface provider usage status and rate limits per provider in the UI.\n\n## Implemented (2026-04-04)\n\n### Codex\n- Full rate limit bars with `usedPercent`, `windowMinutes`, `resetAt` from `account/rateLimits/read` RPC and live `account/rateLimits/updated` events\n- Account info (plan, email) from `account/read`\n- Displayed in both sidecar (provider status section) and global settings page\n- Shared `RateLimitBar` component with `windowLabel()` helper (\"5h window\", \"Weekly\", etc.)\n\n### Claude\n- `rate_limit_event` stream events now handled (previously skipped as telemetry)\n- Accumulates windows by `rateLimitType` (`five_hour`, `seven_day`, etc.)\n- Maps to same `ProviderRateLimitStatus` shape as Codex\n- `accountInfo()` SDK call on session init → populates plan, email, org\n- Hydration on client reconnect via `ensureProviderGlobalState(\"claude\")` harvesting from active sessions\n\n### Limitations (upstream)\n- Claude SDK does not send `utilization` for `allowed` status — only `resetsAt` and window type. Usage percentage only available during `allowed_warning` or `rejected`\n- `seven_day` window events only emitted when near/at the weekly limit\n- No polling API — data only arrives when a session is active and turns fire\n- Rate limit data lost on server restart (no persistence); re-populated after first turn",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -387,14 +394,16 @@
       "type": "task",
       "tags": [],
       "parent": null,
-      "blockedBy": ["4c40cf1a"],
+      "blockedBy": [
+        "4c40cf1a"
+      ],
       "createdAt": "2026-03-09T17:46:11.715826-04:00",
       "updatedAt": "2026-03-12T21:01:40.871548-04:00"
     },
     {
       "id": "335977e7",
       "title": "Improve session load time",
-      "description": "Session loading is noticeably slow. Investigate and optimize the full session hydration path \u2014 JSONL parsing, DB restore, history assembly, and initial WS delivery to the UI. Profile to identify the bottleneck(s) and fix them.",
+      "description": "Session loading is noticeably slow. Investigate and optimize the full session hydration path — JSONL parsing, DB restore, history assembly, and initial WS delivery to the UI. Profile to identify the bottleneck(s) and fix them.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -420,7 +429,7 @@
     {
       "id": "e3fa6290",
       "title": "Integrate Skills support: display, install, and invoke via slash commands",
-      "description": "Integrate Claude Code Skills into Relay. Display installed skills (likely from .claude.json \u2014 we may already have this via readClaudeConfig()), provide way to browse/install new skills from UI, allow /skillname invocation in the text input area. Consider autocomplete/suggestions when typing / in the input area.",
+      "description": "Integrate Claude Code Skills into Relay. Display installed skills (likely from .claude.json — we may already have this via readClaudeConfig()), provide way to browse/install new skills from UI, allow /skillname invocation in the text input area. Consider autocomplete/suggestions when typing / in the input area.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -459,7 +468,7 @@
     {
       "id": "d7604e4e",
       "title": "Interactive plan document review UI",
-      "description": "Add an interactive review UI for **proposed plans** from the model \u2014 not finalized plans in the /plans route. When a model proposes a plan (e.g. via EnterPlanMode or a plan-formatted response), the plan should render as a rich in-chat UI (similar to how AskUserQuestion renders a custom card) with inline review capabilities.\n\n## UX Flow\n\n1. Model proposes a plan \u2192 renders as a custom card/component in the chat message flow (not a plain markdown block)\n2. User can select text passages within the rendered plan and add inline comments \u2014 each comment is anchored to a specific selection\n3. Comments accumulate visually (inline highlights + a comment list), each showing the quoted text + the user's note\n4. User can edit/delete comments before submitting\n5. On submit, all comments are combined into a single structured message (quoted selections + comments) and sent back to the model\n6. Model responds with an updated plan and/or answers to questions\n7. Could also support simple approve/reject without comments (like the existing permission banner pattern)\n\n## Display Options\n\n- **In-chat card**: Rich plan component inline in the message flow, similar to the AskUserQuestion UI or agent transcript cards. Comments appear as annotations on the card itself.\n- **Wide drawer**: If the plan is long, could open in a side drawer (like the diff drawer pattern) for more reading room. Comments in a margin or overlay.\n- Either way, this is part of the chat experience, not the /plans route.\n\n## Implementation Considerations\n\n- Proposed plans come through as assistant messages \u2014 need to detect plan-formatted content (ExitPlanMode tool use, or plan file content in the message)\n- Text selection + anchoring: need to track selection ranges within rendered markdown\n- Comment format sent to model: something like `> [quoted text]\\n\\nComment: [user note]` repeated for each comment\n- Look at existing custom in-chat UIs for patterns: `AgentTranscript`, `AskUserQuestion` rendering in `claude-message.tsx`, permission banner\n- The plan file at `~/.claude/plans/{slug}.md` is the source of truth \u2014 model updates it, we re-read\n- Mobile: text selection is harder on touch, may need a simpler comment-only mode without selection anchoring",
+      "description": "Add an interactive review UI for **proposed plans** from the model — not finalized plans in the /plans route. When a model proposes a plan (e.g. via EnterPlanMode or a plan-formatted response), the plan should render as a rich in-chat UI (similar to how AskUserQuestion renders a custom card) with inline review capabilities.\n\n## UX Flow\n\n1. Model proposes a plan → renders as a custom card/component in the chat message flow (not a plain markdown block)\n2. User can select text passages within the rendered plan and add inline comments — each comment is anchored to a specific selection\n3. Comments accumulate visually (inline highlights + a comment list), each showing the quoted text + the user's note\n4. User can edit/delete comments before submitting\n5. On submit, all comments are combined into a single structured message (quoted selections + comments) and sent back to the model\n6. Model responds with an updated plan and/or answers to questions\n7. Could also support simple approve/reject without comments (like the existing permission banner pattern)\n\n## Display Options\n\n- **In-chat card**: Rich plan component inline in the message flow, similar to the AskUserQuestion UI or agent transcript cards. Comments appear as annotations on the card itself.\n- **Wide drawer**: If the plan is long, could open in a side drawer (like the diff drawer pattern) for more reading room. Comments in a margin or overlay.\n- Either way, this is part of the chat experience, not the /plans route.\n\n## Implementation Considerations\n\n- Proposed plans come through as assistant messages — need to detect plan-formatted content (ExitPlanMode tool use, or plan file content in the message)\n- Text selection + anchoring: need to track selection ranges within rendered markdown\n- Comment format sent to model: something like `> [quoted text]\\n\\nComment: [user note]` repeated for each comment\n- Look at existing custom in-chat UIs for patterns: `AgentTranscript`, `AskUserQuestion` rendering in `claude-message.tsx`, permission banner\n- The plan file at `~/.claude/plans/{slug}.md` is the source of truth — model updates it, we re-read\n- Mobile: text selection is harder on touch, may need a simpler comment-only mode without selection anchoring",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -478,7 +487,9 @@
       "type": "bug",
       "tags": [],
       "parent": null,
-      "blockedBy": ["73adce9a"],
+      "blockedBy": [
+        "73adce9a"
+      ],
       "createdAt": "2026-03-10T20:43:05.687719-04:00",
       "updatedAt": "2026-03-11T06:47:43.127124-04:00"
     },
@@ -745,7 +756,7 @@
     {
       "id": "14861caa",
       "title": "Interactive plan review UI with inline comments",
-      "description": "Add an interactive review UI for **proposed plans** from the model \u2014 not finalized plans in the /plans route. When a model proposes a plan (e.g. via EnterPlanMode or a plan-formatted response), the plan should render as a rich in-chat UI (similar to how AskUserQuestion renders a custom card) with inline review capabilities.\n\n## UX Flow\n\n1. Model proposes a plan \u2192 renders as a custom card/component in the chat message flow (not a plain markdown block)\n2. User can select text passages within the rendered plan and add inline comments \u2014 each comment is anchored to a specific selection\n3. Comments accumulate visually (inline highlights + a comment list), each showing the quoted text + the user's note\n4. User can edit/delete comments before submitting\n5. On submit, all comments are combined into a single structured message (quoted selections + comments) and sent back to the model\n6. Model responds with an updated plan and/or answers to questions\n7. Could also support simple approve/reject without comments (like the existing permission banner pattern)\n\n## Display Options\n\n- **In-chat card**: Rich plan component inline in the message flow, similar to the AskUserQuestion UI or agent transcript cards. Comments appear as annotations on the card itself.\n- **Wide drawer**: If the plan is long, could open in a side drawer (like the diff drawer pattern) for more reading room. Comments in a margin or overlay.\n- Either way, this is part of the chat experience, not the /plans route.\n\n## Implementation Considerations\n\n- Proposed plans come through as assistant messages \u2014 need to detect plan-formatted content (ExitPlanMode tool use, or plan file content in the message)\n- Text selection + anchoring: need to track selection ranges within rendered markdown\n- Comment format sent to model: something like > [quoted text] Comment: [user note] repeated for each comment\n- Look at existing custom in-chat UIs for patterns: AgentTranscript, AskUserQuestion rendering in claude-message.tsx, permission banner\n- The plan file at ~/.claude/plans/{slug}.md is the source of truth \u2014 model updates it, we re-read\n- Mobile: text selection is harder on touch, may need a simpler comment-only mode without selection anchoring",
+      "description": "Add an interactive review UI for **proposed plans** from the model — not finalized plans in the /plans route. When a model proposes a plan (e.g. via EnterPlanMode or a plan-formatted response), the plan should render as a rich in-chat UI (similar to how AskUserQuestion renders a custom card) with inline review capabilities.\n\n## UX Flow\n\n1. Model proposes a plan → renders as a custom card/component in the chat message flow (not a plain markdown block)\n2. User can select text passages within the rendered plan and add inline comments — each comment is anchored to a specific selection\n3. Comments accumulate visually (inline highlights + a comment list), each showing the quoted text + the user's note\n4. User can edit/delete comments before submitting\n5. On submit, all comments are combined into a single structured message (quoted selections + comments) and sent back to the model\n6. Model responds with an updated plan and/or answers to questions\n7. Could also support simple approve/reject without comments (like the existing permission banner pattern)\n\n## Display Options\n\n- **In-chat card**: Rich plan component inline in the message flow, similar to the AskUserQuestion UI or agent transcript cards. Comments appear as annotations on the card itself.\n- **Wide drawer**: If the plan is long, could open in a side drawer (like the diff drawer pattern) for more reading room. Comments in a margin or overlay.\n- Either way, this is part of the chat experience, not the /plans route.\n\n## Implementation Considerations\n\n- Proposed plans come through as assistant messages — need to detect plan-formatted content (ExitPlanMode tool use, or plan file content in the message)\n- Text selection + anchoring: need to track selection ranges within rendered markdown\n- Comment format sent to model: something like > [quoted text] Comment: [user note] repeated for each comment\n- Look at existing custom in-chat UIs for patterns: AgentTranscript, AskUserQuestion rendering in claude-message.tsx, permission banner\n- The plan file at ~/.claude/plans/{slug}.md is the source of truth — model updates it, we re-read\n- Mobile: text selection is harder on touch, may need a simpler comment-only mode without selection anchoring",
       "status": "done",
       "priority": 1,
       "type": "task",
@@ -764,7 +775,9 @@
       "type": "task",
       "tags": [],
       "parent": null,
-      "blockedBy": ["4c40cf1a"],
+      "blockedBy": [
+        "4c40cf1a"
+      ],
       "createdAt": "2026-03-09T17:46:08.707939-04:00",
       "updatedAt": "2026-03-12T21:21:50.766179-04:00"
     },
@@ -810,7 +823,7 @@
     {
       "id": "375d86c5",
       "title": "Investigate and improve session load performance",
-      "description": "Loading an individual session is noticeably slow. Initial app load taking a few seconds is acceptable, but navigating to a specific session should feel near-instant.\n\n**Investigation scope:**\n1. Profile and identify the current bottleneck \u2014 is it JSONL parsing, SQLite queries, WebSocket hydration, UI rendering, or a combination?\n2. Measure where time is spent: server-side (history fetch, JSONL read/parse) vs client-side (message processing, rendering)\n3. Check if we're doing redundant work (re-parsing JSONL that's already been parsed, re-fetching data we already have)\n\n**Potential improvements to evaluate:**\n- Pre-fetching: load session data in the background when hovering/navigating near a session, or eagerly fetch recent sessions on app load\n- Data storage: cache parsed history in SQLite instead of re-parsing JSONL every time a session is opened\n- Faster queries: optimize SQLite access patterns, batch reads, prepared statement reuse\n- Incremental loading: show the last N messages immediately, lazy-load older history\n- Client-side caching: keep previously-loaded sessions in memory so revisiting is instant\n\n**Approach:**\nStart by instrumenting the current flow to identify the actual bottleneck before optimizing. Don't assume \u2014 measure first.",
+      "description": "Loading an individual session is noticeably slow. Initial app load taking a few seconds is acceptable, but navigating to a specific session should feel near-instant.\n\n**Investigation scope:**\n1. Profile and identify the current bottleneck — is it JSONL parsing, SQLite queries, WebSocket hydration, UI rendering, or a combination?\n2. Measure where time is spent: server-side (history fetch, JSONL read/parse) vs client-side (message processing, rendering)\n3. Check if we're doing redundant work (re-parsing JSONL that's already been parsed, re-fetching data we already have)\n\n**Potential improvements to evaluate:**\n- Pre-fetching: load session data in the background when hovering/navigating near a session, or eagerly fetch recent sessions on app load\n- Data storage: cache parsed history in SQLite instead of re-parsing JSONL every time a session is opened\n- Faster queries: optimize SQLite access patterns, batch reads, prepared statement reuse\n- Incremental loading: show the last N messages immediately, lazy-load older history\n- Client-side caching: keep previously-loaded sessions in memory so revisiting is instant\n\n**Approach:**\nStart by instrumenting the current flow to identify the actual bottleneck before optimizing. Don't assume — measure first.",
       "status": "done",
       "priority": 1,
       "type": "task",
@@ -966,7 +979,7 @@
     {
       "id": "556fd544",
       "title": "Consider rebranding sessions to chats or threads",
-      "description": "Rename 'sessions' to something more intuitive in the UI. Candidates: chats (simple, familiar), threads (Slack/Discord style). Routes already use /chats/ so this may mostly be a UI label change. Internal/API naming (SessionDB, sessionId, etc.) is lower priority \u2014 focus on user-facing labels first.",
+      "description": "Rename 'sessions' to something more intuitive in the UI. Candidates: chats (simple, familiar), threads (Slack/Discord style). Routes already use /chats/ so this may mostly be a UI label change. Internal/API naming (SessionDB, sessionId, etc.) is lower priority — focus on user-facing labels first.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -978,7 +991,7 @@
     },
     {
       "id": "0dc34207",
-      "title": "UI/UX pass on sidebar nav \u2014 declutter and clean up",
+      "title": "UI/UX pass on sidebar nav — declutter and clean up",
       "description": "The sidebar navigation has gotten cluttered again. Do a full UI/UX pass to simplify, clean up visual hierarchy, and make it feel less busy.",
       "status": "done",
       "priority": 2,
@@ -1018,7 +1031,7 @@
     {
       "id": "eb2ac414",
       "title": "Surface current git branch name in session UI",
-      "description": "Show the current git branch name for a given session. We already track gitInfo (branch, isWorktree) on instances \u2014 this is about making it visible in the session/chat view in a useful, non-intrusive way.",
+      "description": "Show the current git branch name for a given session. We already track gitInfo (branch, isWorktree) on instances — this is about making it visible in the session/chat view in a useful, non-intrusive way.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -1050,7 +1063,9 @@
       "type": "task",
       "tags": [],
       "parent": null,
-      "blockedBy": ["4c40cf1a"],
+      "blockedBy": [
+        "4c40cf1a"
+      ],
       "createdAt": "2026-03-09T17:46:02.868294-04:00",
       "updatedAt": "2026-03-12T20:33:43.672428-04:00"
     },
@@ -1070,20 +1085,22 @@
     {
       "id": "de1f0ece",
       "title": "Abstract plan discovery beyond ~/.claude/plans/",
-      "description": "Provider-gate plan discovery in getProjectArtifacts(). Currently scans ~/.claude/plans/ unconditionally \u2014 should only run for projects with Claude sessions. The live plan flow (stream \u2192 pendingPlan \u2192 review) is already provider-agnostic; this is just the historical plan discovery for the project /plans page.\n\nScope:\n- Skip plan slug extraction + plan file reads when project has no Claude provider sessions\n- Pass 2 (custom filename discovery) hardcodes `.claude/plans/` \u2014 gate behind provider check\n- Consider surfacing stream-captured plans for non-Claude providers (Codex plans are stream-only)",
+      "description": "Provider-gate plan discovery in getProjectArtifacts(). Currently scans ~/.claude/plans/ unconditionally — should only run for projects with Claude sessions. The live plan flow (stream → pendingPlan → review) is already provider-agnostic; this is just the historical plan discovery for the project /plans page.\n\nScope:\n- Skip plan slug extraction + plan file reads when project has no Claude provider sessions\n- Pass 2 (custom filename discovery) hardcodes `.claude/plans/` — gate behind provider check\n- Consider surfacing stream-captured plans for non-Claude providers (Codex plans are stream-only)",
       "status": "done",
       "priority": 2,
       "type": "task",
       "tags": [],
       "parent": null,
-      "blockedBy": ["4c40cf1a"],
+      "blockedBy": [
+        "4c40cf1a"
+      ],
       "createdAt": "2026-03-09T17:46:05.568906-04:00",
       "updatedAt": "2026-03-15T14:31:10.098411-04:00"
     },
     {
       "id": "7968307e",
       "title": "Remove Agents feature from sidecar",
-      "description": "Remove the Agents/Team feature from the sidecar panel \u2014 unreliable and not enough value for the complexity. Cleanup: ClaudeProcess (teamState, handleJsonlTeamTool, team_info emissions), InstanceManager (instance.team, team syncing), types.ts (team types), Sidecar UI (Team tab, simplify to Tasks + Files only), JSONL parsing (TeamCreate, SendMessage shutdown, TeamDelete in convertJsonlEntry).",
+      "description": "Remove the Agents/Team feature from the sidecar panel — unreliable and not enough value for the complexity. Cleanup: ClaudeProcess (teamState, handleJsonlTeamTool, team_info emissions), InstanceManager (instance.team, team syncing), types.ts (team types), Sidecar UI (Team tab, simplify to Tasks + Files only), JSONL parsing (TeamCreate, SendMessage shutdown, TeamDelete in convertJsonlEntry).",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -1139,7 +1156,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["react", "runtime", "regression"],
+      "tags": [
+        "react",
+        "runtime",
+        "regression"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-18T23:07:52Z",
@@ -1152,7 +1173,10 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["tasks", "migration"],
+      "tags": [
+        "tasks",
+        "migration"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-18T23:53:20Z",
@@ -1165,7 +1189,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["issues", "ui", "sorting"],
+      "tags": [
+        "issues",
+        "ui",
+        "sorting"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-19T00:01:30Z",
@@ -1178,7 +1206,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["docs", "tasks", "model-guidance"],
+      "tags": [
+        "docs",
+        "tasks",
+        "model-guidance"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-19T00:07:30Z",
@@ -1230,7 +1262,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["tasks", "ui", "api"],
+      "tags": [
+        "tasks",
+        "ui",
+        "api"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-19T02:05:47.552Z",
@@ -1256,7 +1292,12 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui", "typescript", "routing", "react"],
+      "tags": [
+        "ui",
+        "typescript",
+        "routing",
+        "react"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-19T02:50:29Z",
@@ -1282,7 +1323,9 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui"],
+      "tags": [
+        "ui"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-19T20:51:59.000Z",
@@ -1295,7 +1338,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui", "header", "layout-shift"],
+      "tags": [
+        "ui",
+        "header",
+        "layout-shift"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T02:51:16.754Z",
@@ -1308,7 +1355,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["ui", "react", "hydration"],
+      "tags": [
+        "ui",
+        "react",
+        "hydration"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T10:42:45.434Z",
@@ -1321,7 +1372,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["spaces", "chat", "ui"],
+      "tags": [
+        "spaces",
+        "chat",
+        "ui"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T13:02:26Z",
@@ -1334,7 +1389,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["ui", "history", "spaces"],
+      "tags": [
+        "ui",
+        "history",
+        "spaces"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T13:11:08Z",
@@ -1347,7 +1406,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["codex", "ui", "history"],
+      "tags": [
+        "codex",
+        "ui",
+        "history"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T13:14:30Z",
@@ -1360,7 +1423,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["ux", "providers", "tasks"],
+      "tags": [
+        "ux",
+        "providers",
+        "tasks"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T13:20:25Z",
@@ -1373,7 +1440,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["git", "projects", "tests"],
+      "tags": [
+        "git",
+        "projects",
+        "tests"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-20T18:18:18Z",
@@ -1395,11 +1466,15 @@
     {
       "id": "3090839f",
       "title": "Add write serialization chain for instance mutations",
-      "description": "Add a promise-based write queue (modeled after Kanna's `writeChain` pattern) to serialize mutations on `Instance` objects in `instance-manager.ts`. Today, the JSONL file watcher, `wireProcessEvents()`, `sendMessage()`, and external discovery all mutate the same `Instance` concurrently across async boundaries with no synchronization. The file-offset tracking in the watcher is the most fragile \u2014 a watcher read can interleave with a process write, causing the offset to desync.\n\nImplementation approach:\n- Introduce a per-instance promise chain (or a shared `EventQueue`) that all mutation paths must go through\n- Ensure watcher updates, process event handling, and `sendMessage()` all enqueue rather than mutate directly\n- Audit every `instance.` mutation site in `instance-manager.ts` for async safety\n- Add tests that exercise concurrent watcher + message paths",
+      "description": "Add a promise-based write queue (modeled after Kanna's `writeChain` pattern) to serialize mutations on `Instance` objects in `instance-manager.ts`. Today, the JSONL file watcher, `wireProcessEvents()`, `sendMessage()`, and external discovery all mutate the same `Instance` concurrently across async boundaries with no synchronization. The file-offset tracking in the watcher is the most fragile — a watcher read can interleave with a process write, causing the offset to desync.\n\nImplementation approach:\n- Introduce a per-instance promise chain (or a shared `EventQueue`) that all mutation paths must go through\n- Ensure watcher updates, process event handling, and `sendMessage()` all enqueue rather than mutate directly\n- Audit every `instance.` mutation site in `instance-manager.ts` for async safety\n- Add tests that exercise concurrent watcher + message paths",
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["stability", "architecture", "instance-manager"],
+      "tags": [
+        "stability",
+        "architecture",
+        "instance-manager"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-22T18:00:00Z",
@@ -1408,11 +1483,15 @@
     {
       "id": "729fcf21",
       "title": "Implement ordered shutdown sequence with SIGKILL fallback",
-      "description": "Replace the current blunt 3-second `setTimeout \u2192 process.exit(1)` shutdown with a proper ordered sequence:\n\n1. Cancel all active turns (flush pending tool responses)\n2. Flush state (compact JSONL, WAL checkpoint SQLite)\n3. Send SIGTERM to all child processes\n4. Wait grace period (~2s)\n5. SIGKILL any still-alive children\n6. Exit\n\nAlso address:\n- `codex-app-server.ts` `close()` sends SIGTERM but doesn't await death\n- Git subprocesses with 2s timeouts can outlive the server\n- No event store compaction or state flush happens on shutdown today\n- Add explicit SQLite WAL checkpoint call on shutdown",
+      "description": "Replace the current blunt 3-second `setTimeout → process.exit(1)` shutdown with a proper ordered sequence:\n\n1. Cancel all active turns (flush pending tool responses)\n2. Flush state (compact JSONL, WAL checkpoint SQLite)\n3. Send SIGTERM to all child processes\n4. Wait grace period (~2s)\n5. SIGKILL any still-alive children\n6. Exit\n\nAlso address:\n- `codex-app-server.ts` `close()` sends SIGTERM but doesn't await death\n- Git subprocesses with 2s timeouts can outlive the server\n- No event store compaction or state flush happens on shutdown today\n- Add explicit SQLite WAL checkpoint call on shutdown",
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["stability", "process-management", "shutdown"],
+      "tags": [
+        "stability",
+        "process-management",
+        "shutdown"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-22T18:00:00Z",
@@ -1421,13 +1500,19 @@
     {
       "id": "aab26187",
       "title": "Separate canonical instance state from derived/display state",
-      "description": "Today the `Instance` object in `instance-manager.ts` serves double duty as both the source of truth and the display model read by WebSocket broadcasts. This means a bug in the broadcast path can corrupt state the process manager relies on, and there's no clear boundary for what's safe to read vs. write.\n\nIntroduce a separation:\n- **Canonical state**: process handle, session ID, provider config, file offsets, pending retry \u2014 only mutated through the write queue (see task 3090839f)\n- **Derived/display state**: sidebar status, transcript entries, activity feed, stats \u2014 computed from canonical state via pure functions, never written back\n\nThis doesn't need to be full CQRS/event-sourcing \u2014 just a clear type-level split (`InstanceCore` vs `InstanceView` or similar) with a `deriveView(instance: InstanceCore): InstanceView` function that the WebSocket layer calls. The key invariant: nothing in the server/WS layer should ever mutate `InstanceCore` directly.",
+      "description": "Today the `Instance` object in `instance-manager.ts` serves double duty as both the source of truth and the display model read by WebSocket broadcasts. This means a bug in the broadcast path can corrupt state the process manager relies on, and there's no clear boundary for what's safe to read vs. write.\n\nIntroduce a separation:\n- **Canonical state**: process handle, session ID, provider config, file offsets, pending retry — only mutated through the write queue (see task 3090839f)\n- **Derived/display state**: sidebar status, transcript entries, activity feed, stats — computed from canonical state via pure functions, never written back\n\nThis doesn't need to be full CQRS/event-sourcing — just a clear type-level split (`InstanceCore` vs `InstanceView` or similar) with a `deriveView(instance: InstanceCore): InstanceView` function that the WebSocket layer calls. The key invariant: nothing in the server/WS layer should ever mutate `InstanceCore` directly.",
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["stability", "architecture", "instance-manager"],
+      "tags": [
+        "stability",
+        "architecture",
+        "instance-manager"
+      ],
       "parent": null,
-      "blockedBy": ["3090839f"],
+      "blockedBy": [
+        "3090839f"
+      ],
       "createdAt": "2026-03-22T18:00:00Z",
       "updatedAt": "2026-03-22T21:10:00Z"
     },
@@ -1438,7 +1523,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["db", "migration", "cleanup"],
+      "tags": [
+        "db",
+        "migration",
+        "cleanup"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-27T16:56:58Z",
@@ -1446,12 +1535,15 @@
     },
     {
       "id": "d35e610e",
-      "title": "Smart Spaces \u2014 shared context, cross-chat coordination, and handoff",
+      "title": "Smart Spaces — shared context, cross-chat coordination, and handoff",
       "description": "Evolve Spaces from isolated worktree containers into collaborative workspaces where chats share context, can be launched from contextual actions, and can pass information between each other. The goal is to make a Space feel like a coordinated team rather than a collection of independent chats that happen to share a branch.",
       "status": "done",
       "priority": 1,
       "type": "epic",
-      "tags": ["spaces", "ux"],
+      "tags": [
+        "spaces",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-27T12:00:00.000Z",
@@ -1459,12 +1551,15 @@
     },
     {
       "id": "810e24c6",
-      "title": "Shared space context \u2014 space-level brief visible to all chats",
-      "description": "Give each space a persistent context document (a \"space brief\") that is automatically injected into every new chat created in that space. This is the space-level analog of project custom_instructions but scoped to the space.\n\n**What it enables:** If a user creates a plan in chat A, they (or Relay) can save it to the space brief. Chat B, C, etc. all receive that plan as context on first turn \u2014 no copy-paste needed.\n\n**Proposed design:**\n- Add a `context` text column to the `spaces` table (or a dedicated `space_context` table if we want versioning)\n- Surface a \"Space Brief\" editor in the space UI header \u2014 editable markdown textarea, collapsed by default\n- On managed session creation within a space, inject the space brief as an internal user message (same pattern as project custom_instructions)\n- When a chat produces a plan (ExitPlanMode / pendingPlan), offer a one-click \"Save to space brief\" action that appends or replaces the space context\n- Relay should also proactively update the space brief as work progresses \u2014 e.g. when a chat completes a task or makes significant progress, auto-append a summary to the brief so other chats stay current. Start with manual curation but build toward Relay maintaining it.\n\n**Scoping decisions:**\n- Brief is injected only at chat creation time \u2014 no mid-conversation injection for now\n- Project instructions + space brief are both injected (additive); space brief comes after project instructions\n- Auto-update of the brief is a stretch goal for v1; manual editing + one-click save-from-plan is the baseline",
+      "title": "Shared space context — space-level brief visible to all chats",
+      "description": "Give each space a persistent context document (a \"space brief\") that is automatically injected into every new chat created in that space. This is the space-level analog of project custom_instructions but scoped to the space.\n\n**What it enables:** If a user creates a plan in chat A, they (or Relay) can save it to the space brief. Chat B, C, etc. all receive that plan as context on first turn — no copy-paste needed.\n\n**Proposed design:**\n- Add a `context` text column to the `spaces` table (or a dedicated `space_context` table if we want versioning)\n- Surface a \"Space Brief\" editor in the space UI header — editable markdown textarea, collapsed by default\n- On managed session creation within a space, inject the space brief as an internal user message (same pattern as project custom_instructions)\n- When a chat produces a plan (ExitPlanMode / pendingPlan), offer a one-click \"Save to space brief\" action that appends or replaces the space context\n- Relay should also proactively update the space brief as work progresses — e.g. when a chat completes a task or makes significant progress, auto-append a summary to the brief so other chats stay current. Start with manual curation but build toward Relay maintaining it.\n\n**Scoping decisions:**\n- Brief is injected only at chat creation time — no mid-conversation injection for now\n- Project instructions + space brief are both injected (additive); space brief comes after project instructions\n- Auto-update of the brief is a stretch goal for v1; manual editing + one-click save-from-plan is the baseline",
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["spaces", "context"],
+      "tags": [
+        "spaces",
+        "context"
+      ],
       "parent": "d35e610e",
       "blockedBy": [],
       "createdAt": "2026-03-27T12:00:00.000Z",
@@ -1473,11 +1568,14 @@
     {
       "id": "1f4d6685",
       "title": "Contextual quick-actions to launch companion chats in a space",
-      "description": "When an agent finishes work (goes idle) or at any time in the space view, surface helper buttons that launch a new chat in the same space with a pre-filled prompt tailored to a specific job.\n\n**Example actions:**\n- \"Review code\" \u2192 opens new chat, auto-sends: \"Review the uncommitted changes in this workspace. Focus on correctness, edge cases, and style.\"\n- \"Run tests\" \u2192 auto-sends: \"Run the test suite and report any failures. If tests fail, analyze the failures but don't fix them yet.\"\n- \"Write tests\" \u2192 auto-sends: \"Write tests for the uncommitted changes in this workspace.\"\n- \"Summarize progress\" \u2192 auto-sends: \"Summarize what has been accomplished in this space so far based on the git diff and chat history.\"\n- \"Continue work\" \u2192 auto-sends: \"Continue working on the space brief / plan. Pick up where the last chat left off.\"\n\n**Proposed design:**\n- Add a quick-action bar to the space tab view (visible in the space header area)\n- Each action is a (label, icon, prompt template) tuple \u2014 start hardcoded, eventually make configurable\n- One-click launch: clicking an action immediately creates a new managed session in the space and auto-sends the prompt (no composer editing step)\n- The prompt template can reference dynamic context: uncommitted diff summary, space brief, task list, etc.\n- If the space brief exists (lay4sc.1), include it automatically in the new chat's context\n\n**Scoping decisions:**\n- Actions are space-level (in the space header), not per-chat (though putting little suggestions above the editor on a chat could be a good pattern too)\n- One-click launch, not editable-before-send\n- Custom action definitions (user-defined prompt templates) \u2014 follow-up, not v1",
+      "description": "When an agent finishes work (goes idle) or at any time in the space view, surface helper buttons that launch a new chat in the same space with a pre-filled prompt tailored to a specific job.\n\n**Example actions:**\n- \"Review code\" → opens new chat, auto-sends: \"Review the uncommitted changes in this workspace. Focus on correctness, edge cases, and style.\"\n- \"Run tests\" → auto-sends: \"Run the test suite and report any failures. If tests fail, analyze the failures but don't fix them yet.\"\n- \"Write tests\" → auto-sends: \"Write tests for the uncommitted changes in this workspace.\"\n- \"Summarize progress\" → auto-sends: \"Summarize what has been accomplished in this space so far based on the git diff and chat history.\"\n- \"Continue work\" → auto-sends: \"Continue working on the space brief / plan. Pick up where the last chat left off.\"\n\n**Proposed design:**\n- Add a quick-action bar to the space tab view (visible in the space header area)\n- Each action is a (label, icon, prompt template) tuple — start hardcoded, eventually make configurable\n- One-click launch: clicking an action immediately creates a new managed session in the space and auto-sends the prompt (no composer editing step)\n- The prompt template can reference dynamic context: uncommitted diff summary, space brief, task list, etc.\n- If the space brief exists (lay4sc.1), include it automatically in the new chat's context\n\n**Scoping decisions:**\n- Actions are space-level (in the space header), not per-chat (though putting little suggestions above the editor on a chat could be a good pattern too)\n- One-click launch, not editable-before-send\n- Custom action definitions (user-defined prompt templates) — follow-up, not v1",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spaces", "ux"],
+      "tags": [
+        "spaces",
+        "ux"
+      ],
       "parent": "d35e610e",
       "blockedBy": [],
       "createdAt": "2026-03-27T12:00:00.000Z",
@@ -1485,12 +1583,16 @@
     },
     {
       "id": "95da848f",
-      "title": "Cross-chat message relay \u2014 \"Send to chat\" action",
+      "title": "Cross-chat message relay — \"Send to chat\" action",
       "description": "Let users grab content from one chat and send it to another chat in the same space, avoiding manual copy-paste between chat tabs.\n\n**Use case:** Chat B reviews code written by chat A. The review produces feedback. User clicks \"Send to Chat A\" on the review message, and chat A receives the feedback as a new user message (or injected context) so it can act on it.\n\n**Proposed design:**\n- Add a \"Send to...\" action to the message context menu (or a dedicated button on assistant messages)\n- Clicking opens a picker showing other chats in the same space\n- Selected content is sent to the target chat as a user-attributed message (prepended with context like \"[From: Review Chat] Here's the code review feedback:\")\n- If the target chat is idle, this acts as a new user turn that wakes it up. If busy, it queues as the next user message.\n- Support sending: (a) a single message, (b) a selection/range of messages, (c) a summary of the chat so far\n\n**Implementation notes:**\n- WS message: `send_to_chat { fromInstanceId, toInstanceId, content, contentType: 'message' | 'summary' }`\n- Server-side: inject the content into the target instance's input queue (same mechanism as the user typing and hitting send)\n- UI: toast confirmation (\"Sent review notes to Chat A\"), maybe a backlink in the target chat (\"Received from Chat B\")\n\n**Key questions:**\n- Should \"send to\" also work across spaces within the same project, or strictly within a space?\n- Should we support sending to a chat that doesn't exist yet (i.e., \"send to new chat\" which creates one)?\n- Rich content: if the source message contains code blocks, file references, etc., should those be preserved or flattened to text?",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spaces", "ux", "cross-chat"],
+      "tags": [
+        "spaces",
+        "ux",
+        "cross-chat"
+      ],
       "parent": "d35e610e",
       "blockedBy": [],
       "createdAt": "2026-03-27T12:00:00.000Z",
@@ -1503,7 +1605,11 @@
       "status": "done",
       "priority": 2,
       "type": "bug",
-      "tags": ["spaces", "git", "diff"],
+      "tags": [
+        "spaces",
+        "git",
+        "diff"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-27T23:55:00Z",
@@ -1512,11 +1618,14 @@
     {
       "id": "f7a1e820",
       "title": "Embedded terminal support",
-      "description": "Add an embedded terminal panel to Relay. xterm.js frontend + node-pty backend with an abstract PtyAdapter layer. Terminals are space-scoped in spaces, chat-scoped in normal chats. Includes terminal output selection \u2192 chat context attachment.",
+      "description": "Add an embedded terminal panel to Relay. xterm.js frontend + node-pty backend with an abstract PtyAdapter layer. Terminals are space-scoped in spaces, chat-scoped in normal chats. Includes terminal output selection → chat context attachment.",
       "status": "done",
       "priority": 1,
       "type": "epic",
-      "tags": ["terminal", "feature"],
+      "tags": [
+        "terminal",
+        "feature"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-27T12:00:00Z",
@@ -1529,7 +1638,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["spaces", "recovery", "merge"],
+      "tags": [
+        "spaces",
+        "recovery",
+        "merge"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-28T02:02:04Z",
@@ -1542,7 +1655,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["performance", "websocket", "history"],
+      "tags": [
+        "performance",
+        "websocket",
+        "history"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-28T02:12:00Z",
@@ -1555,7 +1672,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["ui", "websocket", "chat"],
+      "tags": [
+        "ui",
+        "websocket",
+        "chat"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-03-29T01:58:56.434Z",
@@ -1581,7 +1702,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["architecture", "runtime", "db"],
+      "tags": [
+        "architecture",
+        "runtime",
+        "db"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-02T10:45:00-04:00",
@@ -1594,7 +1719,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui", "sessions", "external"],
+      "tags": [
+        "ui",
+        "sessions",
+        "external"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-03T13:12:50.630Z",
@@ -1607,7 +1736,13 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["debug", "ui", "protocol", "codex", "claude"],
+      "tags": [
+        "debug",
+        "ui",
+        "protocol",
+        "codex",
+        "claude"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-03T15:25:00-04:00",
@@ -1616,11 +1751,15 @@
     {
       "id": "e7a3b1c5",
       "title": "Consolidate instance and space view headers",
-      "description": "The instance header (`instance-header.tsx`) and space header (`space-view-header.tsx`) duplicate significant structure on both mobile and desktop:\n\n- **Mobile layout**: both independently implement hamburger \u2192 title/subtitle \u2192 actions with the same sizing, spacing, and breadcrumb+branch subtitle pattern\n- **Mobile sidecar overlay**: the floating-card wrapper (`fixed inset-0 p-2`, backdrop, `h-[calc(100%-16px)]`) is copy-pasted in `sidecar.tsx` and `space-view-body.tsx`\n- **Desktop layout**: breadcrumb \u2192 status \u2192 title \u2192 badges \u2192 actions is the same skeleton with different slot contents; some differences (e.g. space has inline rename and status badges, instance has provider notices) may be unintentional divergence rather than deliberate\n\nRefactor into:\n1. A shared mobile header component (or make `ViewHeader` mobile-aware) accepting title, subtitle (project+branch), and an actions slot\n2. A shared `MobileSidecarOverlay` component owning the backdrop + floating card wrapper\n3. Audit desktop header differences \u2014 reconcile unintentional divergence, keep intentional differences as slot content",
+      "description": "The instance header (`instance-header.tsx`) and space header (`space-view-header.tsx`) duplicate significant structure on both mobile and desktop:\n\n- **Mobile layout**: both independently implement hamburger → title/subtitle → actions with the same sizing, spacing, and breadcrumb+branch subtitle pattern\n- **Mobile sidecar overlay**: the floating-card wrapper (`fixed inset-0 p-2`, backdrop, `h-[calc(100%-16px)]`) is copy-pasted in `sidecar.tsx` and `space-view-body.tsx`\n- **Desktop layout**: breadcrumb → status → title → badges → actions is the same skeleton with different slot contents; some differences (e.g. space has inline rename and status badges, instance has provider notices) may be unintentional divergence rather than deliberate\n\nRefactor into:\n1. A shared mobile header component (or make `ViewHeader` mobile-aware) accepting title, subtitle (project+branch), and an actions slot\n2. A shared `MobileSidecarOverlay` component owning the backdrop + floating card wrapper\n3. Audit desktop header differences — reconcile unintentional divergence, keep intentional differences as slot content",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui", "refactor", "mobile"],
+      "tags": [
+        "ui",
+        "refactor",
+        "mobile"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-10T19:45:00-04:00",
@@ -1633,7 +1772,12 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["providers", "skills", "composer", "contracts"],
+      "tags": [
+        "providers",
+        "skills",
+        "composer",
+        "contracts"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-11T14:45:13Z",
@@ -1646,7 +1790,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["docs", "cli", "remote"],
+      "tags": [
+        "docs",
+        "cli",
+        "remote"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-11T16:25:00-04:00",
@@ -1659,7 +1807,12 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["remote", "auth", "qr", "ux"],
+      "tags": [
+        "remote",
+        "auth",
+        "qr",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-11T16:37:00-04:00",
@@ -1672,7 +1825,12 @@
       "status": "open",
       "priority": 1,
       "type": "epic",
-      "tags": ["architecture", "remote", "multi-machine", "federation"],
+      "tags": [
+        "architecture",
+        "remote",
+        "multi-machine",
+        "federation"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-11T16:37:00-04:00",
@@ -1685,7 +1843,12 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "chats", "spaces", "workflow"],
+      "tags": [
+        "ux",
+        "chats",
+        "spaces",
+        "workflow"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-11T16:37:00-04:00",
@@ -1789,7 +1952,10 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["handoff", "ux"],
+      "tags": [
+        "handoff",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T00:00:00-04:00",
@@ -1802,7 +1968,10 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spin-off", "ux"],
+      "tags": [
+        "spin-off",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T19:39:21.755Z",
@@ -1815,7 +1984,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spin-off", "selection", "ux"],
+      "tags": [
+        "spin-off",
+        "selection",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T19:43:11.405Z",
@@ -1828,7 +2001,10 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spin-off", "ux"],
+      "tags": [
+        "spin-off",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T19:49:26.051Z",
@@ -1841,7 +2017,10 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["spin-off", "rename"],
+      "tags": [
+        "spin-off",
+        "rename"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T20:00:11.986Z",
@@ -1854,7 +2033,13 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "spaces", "settings", "actions", "composer"],
+      "tags": [
+        "ux",
+        "spaces",
+        "settings",
+        "actions",
+        "composer"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-13T18:30:00Z",
@@ -1867,7 +2052,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["sessions", "managed", "dedup"],
+      "tags": [
+        "sessions",
+        "managed",
+        "dedup"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T01:51:07.387Z",
@@ -1876,11 +2065,17 @@
     {
       "id": "f4b21d87",
       "title": "Start chat or space from a task",
-      "description": "Seamless flow to spin up a new chat or space directly from a task card or task drawer, pre-populated with task context.\n\n## Core Flow\n\n- **\"Start Chat\" button** on task cards (kanban) and task drawer\n- **\"Start Space\" button** on task drawer (creates a space named after the task, seeds first chat)\n- Pre-fills composer with `@task:<id>:<title>` reference \u2014 not auto-sent, user can add context before sending\n- Uses existing `handleCreateChat(initialPrompt?)` pattern and `@task` mention expansion\n\n## UX Enhancements\n\n- **Auto-status update**: optionally set task to `in_progress` when a chat is started from it (toast with undo)\n- **Task badge on chat**: if a chat was spawned from a task, show a small task chip in the chat header linking back to the task\n- **Linked chats in task drawer**: reverse-lookup chats that reference this task (scan `@task:id` in transcripts or lightweight FK); show as a \"Related chats\" section in the drawer\n- **Task-scoped space**: \"Start Space\" uses task title as space name/goal, seeds first chat with the task reference\n\n## Entry Points\n\n- Task card: icon button or context menu \u2192 \"Start Chat\"\n- Task drawer: explicit buttons in header/action area \u2192 \"Start Chat\" / \"Start Space\"\n- Both should navigate to the newly created chat/space after creation\n\n## Implementation Notes\n\n- Leverage existing custom event pattern (`relay:send-to-new-chat`) or direct navigation with state\n- `@task` expansion already gives the model full structured context via XML block\n- Chat pre-fill (not auto-send) is consistent with the suggestion actions direction (task c3a7e910)\n- Consider: which project context to use if task page is project-scoped vs global",
+      "description": "Seamless flow to spin up a new chat or space directly from a task card or task drawer, pre-populated with task context.\n\n## Core Flow\n\n- **\"Start Chat\" button** on task cards (kanban) and task drawer\n- **\"Start Space\" button** on task drawer (creates a space named after the task, seeds first chat)\n- Pre-fills composer with `@task:<id>:<title>` reference — not auto-sent, user can add context before sending\n- Uses existing `handleCreateChat(initialPrompt?)` pattern and `@task` mention expansion\n\n## UX Enhancements\n\n- **Auto-status update**: optionally set task to `in_progress` when a chat is started from it (toast with undo)\n- **Task badge on chat**: if a chat was spawned from a task, show a small task chip in the chat header linking back to the task\n- **Linked chats in task drawer**: reverse-lookup chats that reference this task (scan `@task:id` in transcripts or lightweight FK); show as a \"Related chats\" section in the drawer\n- **Task-scoped space**: \"Start Space\" uses task title as space name/goal, seeds first chat with the task reference\n\n## Entry Points\n\n- Task card: icon button or context menu → \"Start Chat\"\n- Task drawer: explicit buttons in header/action area → \"Start Chat\" / \"Start Space\"\n- Both should navigate to the newly created chat/space after creation\n\n## Implementation Notes\n\n- Leverage existing custom event pattern (`relay:send-to-new-chat`) or direct navigation with state\n- `@task` expansion already gives the model full structured context via XML block\n- Chat pre-fill (not auto-send) is consistent with the suggestion actions direction (task c3a7e910)\n- Consider: which project context to use if task page is project-scoped vs global",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "tasks", "chats", "spaces", "workflow"],
+      "tags": [
+        "ux",
+        "tasks",
+        "chats",
+        "spaces",
+        "workflow"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T14:45:00Z",
@@ -1889,11 +2084,16 @@
     {
       "id": "a92c0e3b",
       "title": "Select-and-reply inline response UX",
-      "description": "Let users select text from an agent message and reply to it inline, building up a composed response from multiple selections.\n\n## Core Flow\n\n1. User highlights text in an agent message\n2. A small popover appears near the selection with a text input\n3. User types a short reply in the popover, confirms (Enter or button)\n4. The selection + reply is captured as a pending reply fragment\n5. User repeats for other parts of the message (e.g. answering multiple questions)\n6. All fragments populate the composer as blockquoted selections with replies underneath:\n   ```\n   > Selected agent text here\n   My reply to that part\n\n   > Another selected passage\n   My reply to this one\n   ```\n7. User can edit the composed message in the composer before sending\n\n## UX Details\n\n- **Selection popover**: minimal \u2014 small text input + confirm. Appears near the selection (above or below). Dismiss on click-away or Escape.\n- **Visual feedback**: after replying to a selection, some indication that a fragment was captured (subtle highlight on the quoted region? a badge/count near the composer?)\n- **Composer population**: fragments appear in order they were created. User can reorder, edit, or delete in the composer before sending.\n- **Keyboard-friendly**: Tab into the popover input after selecting, Enter to confirm, then back to reading the message.\n\n## Prior Art\n\n- Plan mode already has inline comment UX \u2014 may share patterns for selection detection and popover positioning\n- Similar to email quote-reply or Notion's inline comment flow\n\n## Implementation Considerations\n\n- `window.getSelection()` to detect selected text and anchor position\n- Need to handle selection across markdown-rendered content (get plain text, not HTML)\n- Popover positioning relative to selection range bounding rect\n- State: array of `{ selectedText: string, reply: string }` fragments, managed until flushed to composer\n- Formatting as blockquote in composer input (markdown)\n- Consider: should this work on user messages too, or only agent messages?",
+      "description": "Let users select text from an agent message and reply to it inline, building up a composed response from multiple selections.\n\n## Core Flow\n\n1. User highlights text in an agent message\n2. A small popover appears near the selection with a text input\n3. User types a short reply in the popover, confirms (Enter or button)\n4. The selection + reply is captured as a pending reply fragment\n5. User repeats for other parts of the message (e.g. answering multiple questions)\n6. All fragments populate the composer as blockquoted selections with replies underneath:\n   ```\n   > Selected agent text here\n   My reply to that part\n\n   > Another selected passage\n   My reply to this one\n   ```\n7. User can edit the composed message in the composer before sending\n\n## UX Details\n\n- **Selection popover**: minimal — small text input + confirm. Appears near the selection (above or below). Dismiss on click-away or Escape.\n- **Visual feedback**: after replying to a selection, some indication that a fragment was captured (subtle highlight on the quoted region? a badge/count near the composer?)\n- **Composer population**: fragments appear in order they were created. User can reorder, edit, or delete in the composer before sending.\n- **Keyboard-friendly**: Tab into the popover input after selecting, Enter to confirm, then back to reading the message.\n\n## Prior Art\n\n- Plan mode already has inline comment UX — may share patterns for selection detection and popover positioning\n- Similar to email quote-reply or Notion's inline comment flow\n\n## Implementation Considerations\n\n- `window.getSelection()` to detect selected text and anchor position\n- Need to handle selection across markdown-rendered content (get plain text, not HTML)\n- Popover positioning relative to selection range bounding rect\n- State: array of `{ selectedText: string, reply: string }` fragments, managed until flushed to composer\n- Formatting as blockquote in composer input (markdown)\n- Consider: should this work on user messages too, or only agent messages?",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "chat", "composer", "inline-reply"],
+      "tags": [
+        "ux",
+        "chat",
+        "composer",
+        "inline-reply"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-14T14:55:00Z",
@@ -1906,7 +2106,13 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["history", "sessions", "timestamps", "codex", "ux"],
+      "tags": [
+        "history",
+        "sessions",
+        "timestamps",
+        "codex",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-15T11:31:43Z",
@@ -1919,7 +2125,12 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "timestamps", "sidebar", "chat-list"],
+      "tags": [
+        "ux",
+        "timestamps",
+        "sidebar",
+        "chat-list"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-15T12:04:27Z",
@@ -1932,7 +2143,11 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["search", "timestamps", "ux"],
+      "tags": [
+        "search",
+        "timestamps",
+        "ux"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-15T12:15:00Z",
@@ -1945,7 +2160,10 @@
       "status": "done",
       "priority": 2,
       "type": "bug",
-      "tags": ["terminal", "websocket"],
+      "tags": [
+        "terminal",
+        "websocket"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-18T00:00:00.000Z",
@@ -1958,7 +2176,13 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["security", "git", "spaces", "sessions", "db"],
+      "tags": [
+        "security",
+        "git",
+        "spaces",
+        "sessions",
+        "db"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-23T00:21:34Z",
@@ -1971,7 +2195,14 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["tests", "regression", "git", "spaces", "sessions", "db"],
+      "tags": [
+        "tests",
+        "regression",
+        "git",
+        "spaces",
+        "sessions",
+        "db"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-23T00:36:53Z",
@@ -1984,7 +2215,12 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["tasks", "storage", "git", "migration"],
+      "tags": [
+        "tasks",
+        "storage",
+        "git",
+        "migration"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-04-23T19:52:00Z",
@@ -1993,11 +2229,14 @@
     {
       "id": "9328fdc4",
       "title": "Toast when an agent turn ends in a non-focused chat",
-      "description": "When an agent turn finishes in a chat that the user is not currently viewing (different chat, different page, or tab not focused), pop a toast notifying them that the chat is ready. Clicking the toast should navigate to that chat.\n\n**Trigger condition:** an instance transitions from running \u2192 idle (turn end) AND the user is not actively viewing that chat. \"Not viewing\" covers: looking at a different chat, on a non-chat page (settings, plans, tasks, etc.), or the browser tab is hidden (`document.visibilityState === 'hidden'`).\n\n**Implementation notes:**\n- Detect the running\u2192idle transition client-side by diffing instance status across WS updates (similar pattern to `prevInstanceIdsRef` in `app/src/context/action-toast-context.tsx`).\n- Compare against the currently-focused chat ID (available from the router / sidebar nav controller).\n- Use `sonner` toasts with the chat name + a click handler that navigates to the chat.\n- Consider rate-limiting / coalescing if multiple chats finish in quick succession.\n- Optional: also flash `document.title` or favicon when the tab is hidden, since toasts won't be visible.\n- Optional follow-up: browser Notification API for true OS-level alerts (requires permission).\n\n**Open questions:**\n- Should this fire for every turn end, or only when the user explicitly sent a message and walked away? (Avoid toast spam from agents doing multi-turn tool loops that punctuate at idle moments.)\n- Should rate-limit / completion notifications be a separate category from turn-end?",
+      "description": "When an agent turn finishes in a chat that the user is not currently viewing (different chat, different page, or tab not focused), pop a toast notifying them that the chat is ready. Clicking the toast should navigate to that chat.\n\n**Trigger condition:** an instance transitions from running → idle (turn end) AND the user is not actively viewing that chat. \"Not viewing\" covers: looking at a different chat, on a non-chat page (settings, plans, tasks, etc.), or the browser tab is hidden (`document.visibilityState === 'hidden'`).\n\n**Implementation notes:**\n- Detect the running→idle transition client-side by diffing instance status across WS updates (similar pattern to `prevInstanceIdsRef` in `app/src/context/action-toast-context.tsx`).\n- Compare against the currently-focused chat ID (available from the router / sidebar nav controller).\n- Use `sonner` toasts with the chat name + a click handler that navigates to the chat.\n- Consider rate-limiting / coalescing if multiple chats finish in quick succession.\n- Optional: also flash `document.title` or favicon when the tab is hidden, since toasts won't be visible.\n- Optional follow-up: browser Notification API for true OS-level alerts (requires permission).\n\n**Open questions:**\n- Should this fire for every turn end, or only when the user explicitly sent a message and walked away? (Avoid toast spam from agents doing multi-turn tool loops that punctuate at idle moments.)\n- Should rate-limit / completion notifications be a separate category from turn-end?",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "notifications"],
+      "tags": [
+        "ux",
+        "notifications"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-05-05T00:00:00Z",
@@ -2010,7 +2249,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["ui", "performance", "chat"],
+      "tags": [
+        "ui",
+        "performance",
+        "chat"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-05-12T18:13:02Z",
@@ -2019,11 +2262,14 @@
     {
       "id": "b3e9f1a2",
       "title": "Inject space-brief contents into chat bootstrap context (complete the port custom_instructions got in 12fc245)",
-      "description": "Each space's brief (`.relay/space-context.md`) was not reaching the model: chats only received a POINTER instruction to go read the file, never its contents \u2014 so in practice users had to manually paste the context into every chat.\n\nHistory (verified, not an accidental regression): originally (task 810e24c6, Smart Spaces epic d35e610e) the brief's contents WERE injected \u2014 but on every turn, as a `<space-context>`-wrapped USER message, plus a live sibling-chat roster (`buildSpaceContext` + `buildSpaceContextPrompt`, read the file via readSpaceContext and embedded it under \"Current shared context\"). Commit 12fc245 (\"move managed-session instructions into bootstrap context\") INTENTIONALLY removed that path \u2014 it added a fresh test asserting the contents are absent (\"keeps normal turns unwrapped\"). The removal fixed two real problems: (1) per-turn re-injection of the whole file + roster grew context every turn; (2) injecting it as a user message made it surface as visible user messages in replayed chats (bug cluster 31962115/cfeec325/a6f28510, tagged spaces). In the same commit, project custom_instructions were ported to inject their TEXT via the new bootstrap-block path \u2014 but the space brief was ported as a pointer only. That asymmetry (incomplete port, not a considered \"pointer is enough\" decision per the bare commit message) is what this task fixes.\n\nFix: inject the brief's CONTENTS via the bootstrap-block path (`buildSpaceBootstrapContextBlock` + new `extractSpaceContextForInjection`), the same mechanism custom_instructions use. This threads both of 12fc245's concerns: injected once at session start (not per-turn \u2192 no growth) and as a bootstrap block (not a user message \u2192 no visible-message bug). The existing read-it/re-read-it pointer is kept for freshness. Inject only when the file has authored content beyond the seed template (strip headers/HTML comments). New/resumed chats only \u2014 no editor, no write endpoint; authoring stays via agents in live chat.\n\nKnown tradeoff vs. the old path: bootstrap injection is a point-in-time snapshot at session start, so a sibling rewriting the brief mid-session leaves the injected copy stale (the retained re-read pointer is the freshness path then). Acceptable for the stable human/agent-curated, new-chats-only use case.\n\nTests: flipped the existing instance-manager.test.js assertion that contents are NOT injected \u2192 now asserts they ARE; added a negative case (seed-template-only file injects no contents) and unit tests for extractSpaceContextForInjection (session-context.test.js). Documented the behavior in AGENTS.md Spaces section.",
+      "description": "Each space's brief (`.relay/space-context.md`) was not reaching the model: chats only received a POINTER instruction to go read the file, never its contents — so in practice users had to manually paste the context into every chat.\n\nHistory (verified, not an accidental regression): originally (task 810e24c6, Smart Spaces epic d35e610e) the brief's contents WERE injected — but on every turn, as a `<space-context>`-wrapped USER message, plus a live sibling-chat roster (`buildSpaceContext` + `buildSpaceContextPrompt`, read the file via readSpaceContext and embedded it under \"Current shared context\"). Commit 12fc245 (\"move managed-session instructions into bootstrap context\") INTENTIONALLY removed that path — it added a fresh test asserting the contents are absent (\"keeps normal turns unwrapped\"). The removal fixed two real problems: (1) per-turn re-injection of the whole file + roster grew context every turn; (2) injecting it as a user message made it surface as visible user messages in replayed chats (bug cluster 31962115/cfeec325/a6f28510, tagged spaces). In the same commit, project custom_instructions were ported to inject their TEXT via the new bootstrap-block path — but the space brief was ported as a pointer only. That asymmetry (incomplete port, not a considered \"pointer is enough\" decision per the bare commit message) is what this task fixes.\n\nFix: inject the brief's CONTENTS via the bootstrap-block path (`buildSpaceBootstrapContextBlock` + new `extractSpaceContextForInjection`), the same mechanism custom_instructions use. This threads both of 12fc245's concerns: injected once at session start (not per-turn → no growth) and as a bootstrap block (not a user message → no visible-message bug). The existing read-it/re-read-it pointer is kept for freshness. Inject only when the file has authored content beyond the seed template (strip headers/HTML comments). New/resumed chats only — no editor, no write endpoint; authoring stays via agents in live chat.\n\nKnown tradeoff vs. the old path: bootstrap injection is a point-in-time snapshot at session start, so a sibling rewriting the brief mid-session leaves the injected copy stale (the retained re-read pointer is the freshness path then). Acceptable for the stable human/agent-curated, new-chats-only use case.\n\nTests: flipped the existing instance-manager.test.js assertion that contents are NOT injected → now asserts they ARE; added a negative case (seed-template-only file injects no contents) and unit tests for extractSpaceContextForInjection (session-context.test.js). Documented the behavior in AGENTS.md Spaces section.",
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["spaces", "context"],
+      "tags": [
+        "spaces",
+        "context"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-04T00:00:00.000Z",
@@ -2032,11 +2278,15 @@
     {
       "id": "f3a2b1c0",
       "title": "Support inline /skill invocation mid-message",
-      "description": "Allow `/skill-name` to be typed and triggered anywhere in a message, not just at the start \u2014 matching how Claude's web interface handles it.\n\n## Motivation\n\nUsers want to write messages like:\n> \"Here are my thoughts on the various things we've discussed. Can you use the /grill-me skill to hone in on the details.\"\n\nCurrently `getCommandContext()` in `shared.tsx` only fires when `/` is the first non-whitespace character of the message. The `@` mention trigger works anywhere via word-boundary detection from the cursor; `/` should do the same.\n\n## Design\n\n**Trigger detection** (`shared.tsx` + `composer-mentions.ts`):\n- Add `detectSlashTrigger(text, cursor)` mirroring `detectMentionTrigger` \u2014 walk back from cursor to whitespace/start; if token starts with `/`, open the skill menu.\n- Only fire when `/` is preceded by whitespace or is at position 0 (prevents false positives on file paths like `src/utils/foo.ts`).\n- Suppress the menu when inside a `$`-prefixed shell command line (existing behavior).\n\n**Editor node** (`composer-editor.tsx`):\n- Reuse `ComposerSlashNode` \u2014 selecting from the inline menu inserts it as a chip in the middle of the text, not replacing the whole input.\n\n**Serialization** (`splitPromptIntoComposerSegments` / `$setComposerText`):\n- Mid-message slash chips serialize to `/skill-name` in the text (same as they do today at position 0).\n\n**Submit handler** (`input-area.tsx`):\n- On send, scan submitted text for `/skill-name` tokens (whitespace-bounded or at start).\n- If found, extract the skill name and invoke the skill with the full message text (minus the chip token, or with it \u2014 TBD) as `args`.\n- Existing start-of-message skill dispatch is the canonical path; this is an extension of it.\n\n## Key files\n- `app/src/components/chat/input-area/shared.tsx` \u2014 `getCommandContext()` \u2192 add `detectSlashTrigger()`\n- `app/src/lib/composer-mentions.ts` \u2014 `splitPromptIntoComposerSegments`, `detectMentionTrigger` (model for slash version)\n- `app/src/components/chat/input-area/use-composer-menus.tsx` \u2014 wire new trigger into menu open logic\n- `app/src/components/chat/composer-editor.tsx` \u2014 `ComposerSlashNode` chip insertion mid-message\n- `app/src/components/chat/input-area.tsx` \u2014 submit handler skill extraction",
+      "description": "Allow `/skill-name` to be typed and triggered anywhere in a message, not just at the start — matching how Claude's web interface handles it.\n\n## Motivation\n\nUsers want to write messages like:\n> \"Here are my thoughts on the various things we've discussed. Can you use the /grill-me skill to hone in on the details.\"\n\nCurrently `getCommandContext()` in `shared.tsx` only fires when `/` is the first non-whitespace character of the message. The `@` mention trigger works anywhere via word-boundary detection from the cursor; `/` should do the same.\n\n## Design\n\n**Trigger detection** (`shared.tsx` + `composer-mentions.ts`):\n- Add `detectSlashTrigger(text, cursor)` mirroring `detectMentionTrigger` — walk back from cursor to whitespace/start; if token starts with `/`, open the skill menu.\n- Only fire when `/` is preceded by whitespace or is at position 0 (prevents false positives on file paths like `src/utils/foo.ts`).\n- Suppress the menu when inside a `$`-prefixed shell command line (existing behavior).\n\n**Editor node** (`composer-editor.tsx`):\n- Reuse `ComposerSlashNode` — selecting from the inline menu inserts it as a chip in the middle of the text, not replacing the whole input.\n\n**Serialization** (`splitPromptIntoComposerSegments` / `$setComposerText`):\n- Mid-message slash chips serialize to `/skill-name` in the text (same as they do today at position 0).\n\n**Submit handler** (`input-area.tsx`):\n- On send, scan submitted text for `/skill-name` tokens (whitespace-bounded or at start).\n- If found, extract the skill name and invoke the skill with the full message text (minus the chip token, or with it — TBD) as `args`.\n- Existing start-of-message skill dispatch is the canonical path; this is an extension of it.\n\n## Key files\n- `app/src/components/chat/input-area/shared.tsx` — `getCommandContext()` → add `detectSlashTrigger()`\n- `app/src/lib/composer-mentions.ts` — `splitPromptIntoComposerSegments`, `detectMentionTrigger` (model for slash version)\n- `app/src/components/chat/input-area/use-composer-menus.tsx` — wire new trigger into menu open logic\n- `app/src/components/chat/composer-editor.tsx` — `ComposerSlashNode` chip insertion mid-message\n- `app/src/components/chat/input-area.tsx` — submit handler skill extraction",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ux", "composer", "skills"],
+      "tags": [
+        "ux",
+        "composer",
+        "skills"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-04T03:00:00.000Z",
@@ -2045,11 +2295,14 @@
     {
       "id": "e4b8c7d1",
       "title": "Fix plan-review panel reappearing after accept/dismiss",
-      "description": "The plan-review panel re-opened a turn after the user accepted or dismissed a plan.\n\n## Root cause\n\n`syncPendingInteractiveState` (server/core/instance-manager.ts) unconditionally set `pendingPlan` whenever it saw an `ExitPlanMode` activity. After the user accepts/dismisses, `dispatchUserMessageLocked` flips `runtimeMode` from `\"plan\"` to `\"approval-required\"` and clears `pendingPlan` \u2014 but the SDK subprocess can still be in `plan` permissionMode (`setRuntimeMode` calls `query.setPermissionMode(\"default\")` but the model may already be mid-flight), so the model emits another `ExitPlanMode`. That re-fire re-set `pendingPlan` and re-opened the panel.\n\n## Fix\n\nGate the `pendingPlan` assignment on `instance.info.runtimeMode === \"plan\"`. `planContent` is still always updated (for sidebar display). Once the session is in `approval-required` mode, subsequent `ExitPlanMode` calls fall through to the standard permission-banner path instead of reopening the plan panel. This aligns with `refreshPendingPlan`, which already gates on `runtimeMode === \"plan\"`.\n\nVerified the fix is sound across all three `syncPendingInteractiveState` call sites: live activity (current runtimeMode), restore + lazy hydration (`runtimeMode` populated from the persisted `runtime_mode` column before hydration runs), and the JSONL watcher (live runtimeMode). Accept and dismiss converge on the same `dispatchUserMessageLocked` state transition, so both are covered.\n\n## Tests\n\nAdded two regression tests to instance-manager.test.js asserting that a stray `ExitPlanMode` after both accept and dismiss does NOT re-set `pendingPlan` (while `planContent` still updates).\n\n## Out of scope\n\nThe user-question (`AskUserQuestion`) panel was reported with similar symptoms but left untouched: each question carries a unique requestId, so the model legitimately re-asking is expected behavior, distinct from the plan re-appearance bug. Deferred pending a confirmed repro.",
+      "description": "The plan-review panel re-opened a turn after the user accepted or dismissed a plan.\n\n## Root cause\n\n`syncPendingInteractiveState` (server/core/instance-manager.ts) unconditionally set `pendingPlan` whenever it saw an `ExitPlanMode` activity. After the user accepts/dismisses, `dispatchUserMessageLocked` flips `runtimeMode` from `\"plan\"` to `\"approval-required\"` and clears `pendingPlan` — but the SDK subprocess can still be in `plan` permissionMode (`setRuntimeMode` calls `query.setPermissionMode(\"default\")` but the model may already be mid-flight), so the model emits another `ExitPlanMode`. That re-fire re-set `pendingPlan` and re-opened the panel.\n\n## Fix\n\nGate the `pendingPlan` assignment on `instance.info.runtimeMode === \"plan\"`. `planContent` is still always updated (for sidebar display). Once the session is in `approval-required` mode, subsequent `ExitPlanMode` calls fall through to the standard permission-banner path instead of reopening the plan panel. This aligns with `refreshPendingPlan`, which already gates on `runtimeMode === \"plan\"`.\n\nVerified the fix is sound across all three `syncPendingInteractiveState` call sites: live activity (current runtimeMode), restore + lazy hydration (`runtimeMode` populated from the persisted `runtime_mode` column before hydration runs), and the JSONL watcher (live runtimeMode). Accept and dismiss converge on the same `dispatchUserMessageLocked` state transition, so both are covered.\n\n## Tests\n\nAdded two regression tests to instance-manager.test.js asserting that a stray `ExitPlanMode` after both accept and dismiss does NOT re-set `pendingPlan` (while `planContent` still updates).\n\n## Out of scope\n\nThe user-question (`AskUserQuestion`) panel was reported with similar symptoms but left untouched: each question carries a unique requestId, so the model legitimately re-asking is expected behavior, distinct from the plan re-appearance bug. Deferred pending a confirmed repro.",
       "status": "done",
       "priority": 2,
       "type": "bug",
-      "tags": ["plan-mode", "composer"],
+      "tags": [
+        "plan-mode",
+        "composer"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-06T00:00:00.000Z",
@@ -2058,7 +2311,7 @@
     {
       "id": "7b3e9f02",
       "title": "Surface aggregate chat state on space-group branch icon",
-      "description": "Expand the per-chat SessionIndicator semantics out to SidebarSpaceGroup: the GitBranch icon reflects the combined live state of the space's member chats so activity is visible without opening the space or waiting for a toast.\n\n**Aggregate states + precedence** (single icon; highest wins):\n1. Running \u2014 any member `processing`/`pendingTool` \u2192 `text-warning` + `animate-pulse-dot`\n2. Error \u2014 any member `error` \u2192 `text-error`, static\n3. Completed \u2014 any member `unread` \u2192 `text-accent`, static\n4. None \u2014 baseline `isActive ? text-accent : text-muted`\n\nActivity color overrides the active-space accent baseline. Pulse reserved for running only.\n\n**Members:** `instance.spaceId === space.id`, including external sessions. Effect applies only to active+broken spaces (closed spaces stay baseline). Unread derived purely from `selectHasUnread` (no space-level clearing); clears organically as chats are read.\n\n**Tooltip:** count-aware, precedence-led (e.g. \"1 chat waiting for permission\" / \"2 chats running\" / \"1 chat errored\" / \"3 unread chats\"); prioritizes the permission count over plain processing when running.\n\n**Impl:** SidebarProjectGroup passes `groupInstances.filter(i => i.spaceId === space.id)` into SidebarSpaceGroup; status aggregate from props, unread aggregate via a useUnreadStore boolean selector; reuse `deriveInstanceStatusPresentation` + exported `dotClassToTextColor` for single-sourced colors; wrap the icon in a Tooltip.",
+      "description": "Expand the per-chat SessionIndicator semantics out to SidebarSpaceGroup: the GitBranch icon reflects the combined live state of the space's member chats so activity is visible without opening the space or waiting for a toast.\n\n**Aggregate states + precedence** (single icon; highest wins):\n1. Running — any member `processing`/`pendingTool` → `text-warning` + `animate-pulse-dot`\n2. Error — any member `error` → `text-error`, static\n3. Completed — any member `unread` → `text-accent`, static\n4. None — baseline `isActive ? text-accent : text-muted`\n\nActivity color overrides the active-space accent baseline. Pulse reserved for running only.\n\n**Members:** `instance.spaceId === space.id`, including external sessions. Effect applies only to active+broken spaces (closed spaces stay baseline). Unread derived purely from `selectHasUnread` (no space-level clearing); clears organically as chats are read.\n\n**Tooltip:** count-aware, precedence-led (e.g. \"1 chat waiting for permission\" / \"2 chats running\" / \"1 chat errored\" / \"3 unread chats\"); prioritizes the permission count over plain processing when running.\n\n**Impl:** SidebarProjectGroup passes `groupInstances.filter(i => i.spaceId === space.id)` into SidebarSpaceGroup; status aggregate from props, unread aggregate via a useUnreadStore boolean selector; reuse `deriveInstanceStatusPresentation` + exported `dotClassToTextColor` for single-sourced colors; wrap the icon in a Tooltip.",
       "status": "done",
       "priority": 2,
       "type": "task",
@@ -2075,7 +2328,10 @@
       "status": "done",
       "priority": 3,
       "type": "task",
-      "tags": ["ui", "input-area"],
+      "tags": [
+        "ui",
+        "input-area"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-08T00:02:00.000Z",
@@ -2084,11 +2340,15 @@
     {
       "id": "f1c4d7a8",
       "title": "AskUserQuestion panel reappears on reload after answer/dismiss",
-      "description": "After answering or dismissing an AskUserQuestion panel, the panel reappears on PAGE RELOAD (not via a live re-ask). Manual repro: dismiss \u2192 panel gone, stays gone across chat navigation \u2192 reload page \u2192 panel renders on load.\n\n## Root cause\n\nThe panel is driven by `instance.info.pendingPermission`. On reload/hydration (and on the JSONL watcher's end-of-turn replay), `syncPendingInteractiveState` replays transcript activities: an `AskUserQuestion` tool_use re-sets `pendingPermission` (kind `user_input`), and it is supposed to be cleared by the following tool_result. The clearing condition matched `activity.tool === \"AskUserQuestion\"`.\n\nBut `buildToolResultActivity` (tools.ts) only populates `activity.tool` for permission *denials* (`deniedTool`); a normal answered/dismissed question result has `tool: undefined` and instead carries `resolution: \"approved\"|\"dismissed\"`. So on replay the clear never fired and `pendingPermission` stayed set \u2192 stale panel on reload.\n\nThis affects submit too, not just dismiss; it's normally masked because a follow-up user message clears the pending state via the user-message branch. It only surfaces when the last interaction was an answered question with no follow-up.\n\nNote: distinct from the decline fix (task c5e1a9f4) \u2014 `isPermissionDenial` does not match the SDK's \"Request declined\", so that fix does not populate `tool` and does not resolve this.\n\n## Fix\n\nIn `syncPendingInteractiveState`, clear a pending `user_input` on a tool_result that carries a `resolution` (reliable for resolved interactive results in both live and replay paths), in addition to the `tool === \"AskUserQuestion\"` match. Sequential replay keeps this order-safe (each question's tool_use sets pending; its resolution clears it; a still-unanswered trailing question stays pending).\n\n## Tests\n\nAdded a `rebuildPendingInteractiveState (AskUserQuestion replay)` block to instance-manager.test.js that parses REAL JSONL (so the tool_result has the true parsed shape: `tool: undefined` + `resolution: \"approved\"`), asserts that shape, then asserts rebuild clears `pendingPermission`. Negative control: a tool_use with no tool_result stays pending. Verified the positive test fails when the fix is reverted to the tool-only match.",
+      "description": "After answering or dismissing an AskUserQuestion panel, the panel reappears on PAGE RELOAD (not via a live re-ask). Manual repro: dismiss → panel gone, stays gone across chat navigation → reload page → panel renders on load.\n\n## Root cause\n\nThe panel is driven by `instance.info.pendingPermission`. On reload/hydration (and on the JSONL watcher's end-of-turn replay), `syncPendingInteractiveState` replays transcript activities: an `AskUserQuestion` tool_use re-sets `pendingPermission` (kind `user_input`), and it is supposed to be cleared by the following tool_result. The clearing condition matched `activity.tool === \"AskUserQuestion\"`.\n\nBut `buildToolResultActivity` (tools.ts) only populates `activity.tool` for permission *denials* (`deniedTool`); a normal answered/dismissed question result has `tool: undefined` and instead carries `resolution: \"approved\"|\"dismissed\"`. So on replay the clear never fired and `pendingPermission` stayed set → stale panel on reload.\n\nThis affects submit too, not just dismiss; it's normally masked because a follow-up user message clears the pending state via the user-message branch. It only surfaces when the last interaction was an answered question with no follow-up.\n\nNote: distinct from the decline fix (task c5e1a9f4) — `isPermissionDenial` does not match the SDK's \"Request declined\", so that fix does not populate `tool` and does not resolve this.\n\n## Fix\n\nIn `syncPendingInteractiveState`, clear a pending `user_input` on a tool_result that carries a `resolution` (reliable for resolved interactive results in both live and replay paths), in addition to the `tool === \"AskUserQuestion\"` match. Sequential replay keeps this order-safe (each question's tool_use sets pending; its resolution clears it; a still-unanswered trailing question stays pending).\n\n## Tests\n\nAdded a `rebuildPendingInteractiveState (AskUserQuestion replay)` block to instance-manager.test.js that parses REAL JSONL (so the tool_result has the true parsed shape: `tool: undefined` + `resolution: \"approved\"`), asserts that shape, then asserts rebuild clears `pendingPermission`. Negative control: a tool_use with no tool_result stays pending. Verified the positive test fails when the fix is reverted to the tool-only match.",
       "status": "done",
       "priority": 2,
       "type": "bug",
-      "tags": ["input-area", "ask-user-question", "hydration"],
+      "tags": [
+        "input-area",
+        "ask-user-question",
+        "hydration"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-08T00:03:00.000Z",
@@ -2097,11 +2357,15 @@
     {
       "id": "c8e2a4f1",
       "title": "Show AskUserQuestion answers as chat messages",
-      "description": "When a user submits answers via the AskUserQuestion panel, no visible user message appeared in the chat \u2014 the answer went silently to the model via respond_to_request.\n\n## Root cause\n\nFor the Claude SDK provider path, `resolveRequestLocked` calls `instance.process.respondToRequest()` which returns `true` and the method returned early \u2014 skipping the `dispatchUserMessageLocked` call that the non-SDK (CLI) path uses to emit a visible `instance:user` event.\n\n## Fix\n\nAfter `respondToRequest` returns `true` for a `user_input` request, build the reply text via `buildUserInputReply` and emit `instance:user` + `pushHistory` directly, without re-sending anything to the provider. Also updated `buildUserInputReply` to format answers as markdown blockquotes: each answered question renders as `> Question text` followed by the answer on a new paragraph, with multiple Q&A pairs separated by blank lines.",
+      "description": "When a user submits answers via the AskUserQuestion panel, no visible user message appeared in the chat — the answer went silently to the model via respond_to_request.\n\n## Root cause\n\nFor the Claude SDK provider path, `resolveRequestLocked` calls `instance.process.respondToRequest()` which returns `true` and the method returned early — skipping the `dispatchUserMessageLocked` call that the non-SDK (CLI) path uses to emit a visible `instance:user` event.\n\n## Fix\n\nAfter `respondToRequest` returns `true` for a `user_input` request, build the reply text via `buildUserInputReply` and emit `instance:user` + `pushHistory` directly, without re-sending anything to the provider. Also updated `buildUserInputReply` to format answers as markdown blockquotes: each answered question renders as `> Question text` followed by the answer on a new paragraph, with multiple Q&A pairs separated by blank lines.",
       "status": "done",
       "priority": 2,
       "type": "bug",
-      "tags": ["input-area", "ask-user-question", "chat"],
+      "tags": [
+        "input-area",
+        "ask-user-question",
+        "chat"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-10T19:02:34.000Z",
@@ -2110,11 +2374,15 @@
     {
       "id": "d0ad19a0",
       "title": "Make Claude rate-limit reporting consistent and accurate",
-      "description": "5h window shows '\u2014' or a false 'maxed' full bar. Root causes: (1) handleRateLimitEvent fully overwrites window data, dropping known utilization when an `allowed` event arrives without one; (2) get_usage snapshot seeding is all-or-nothing per window, so a live event occupying the five_hour slot permanently blocks the snapshot's authoritative utilization; (3) a stale `rejected` latches in mergeRateLimitWindows because the escape hatch (usedPercent < 100) never fires for windows that never get a percentage. Fix: field-level merges at session level, clear rejected when snapshot utilization < 100, periodic get_usage re-probe at turn end, and carry usedPercent forward in instance-manager merge.",
+      "description": "5h window shows '—' or a false 'maxed' full bar. Root causes: (1) handleRateLimitEvent fully overwrites window data, dropping known utilization when an `allowed` event arrives without one; (2) get_usage snapshot seeding is all-or-nothing per window, so a live event occupying the five_hour slot permanently blocks the snapshot's authoritative utilization; (3) a stale `rejected` latches in mergeRateLimitWindows because the escape hatch (usedPercent < 100) never fires for windows that never get a percentage. Fix: field-level merges at session level, clear rejected when snapshot utilization < 100, periodic get_usage re-probe at turn end, and carry usedPercent forward in instance-manager merge.",
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["providers", "claude", "rate-limits"],
+      "tags": [
+        "providers",
+        "claude",
+        "rate-limits"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-11T22:24:46.963Z",
@@ -2123,11 +2391,15 @@
     {
       "id": "fa7c0d01",
       "title": "Address review findings on sidebar favicon scanner",
-      "description": "Followups on the new score-and-pick-best favicon scanner. Extracted the scanner to its own pure module (server/core/favicon-scanner.ts) and addressed all five review findings:\n\n1. Manifest icons are now scored candidates in the same pool as filesystem matches (base 8500 / 7500 for maskable-only, with declared `sizes` adding the size bonus). Hashed icon filenames declared in PWA manifests now beat stray logo.png files in the tree.\n2. Added path-aware bias (project name/slug segment match: +120/+60, filename match: +80, conventional app-root segment: +40) plus deterministic tie-breakers (shallower path \u2192 shorter path \u2192 lexicographic). InstanceManager passes the project's `name` and `slug` through.\n3. Replaced the single `MAX_FILES` cap with two independent budgets: `maxIconCandidates` (default 500, counts only plausible icon files) and `maxFileEntries` (default 50k, safety net). Noisy dirs full of non-icon files can no longer starve the manifest check.\n4. Manifest icons are accumulated and scored globally \u2014 no more first-manifest-wins. Also added priority-directory ordering (public/static/assets/Sources/etc. visited first) so the budget is spent in the right places.\n5. Added test/favicon-scanner.test.js with 30 fixture-based tests covering: scoring rules, manifest parsing (PWA + extension shape + maskable-only + missing src), Xcode appiconset, ghin-plus + usage-meter regression cases, projectNames tie-breaking, shallower-path tie-breaking, hashed-manifest-icon-beats-logo, two-manifests-larger-wins, node_modules skip, and the maxIconCandidates budget.\n\nVerified live against the real ghin-plus, usage-meter, and relay repos.",
+      "description": "Followups on the new score-and-pick-best favicon scanner. Extracted the scanner to its own pure module (server/core/favicon-scanner.ts) and addressed all five review findings:\n\n1. Manifest icons are now scored candidates in the same pool as filesystem matches (base 8500 / 7500 for maskable-only, with declared `sizes` adding the size bonus). Hashed icon filenames declared in PWA manifests now beat stray logo.png files in the tree.\n2. Added path-aware bias (project name/slug segment match: +120/+60, filename match: +80, conventional app-root segment: +40) plus deterministic tie-breakers (shallower path → shorter path → lexicographic). InstanceManager passes the project's `name` and `slug` through.\n3. Replaced the single `MAX_FILES` cap with two independent budgets: `maxIconCandidates` (default 500, counts only plausible icon files) and `maxFileEntries` (default 50k, safety net). Noisy dirs full of non-icon files can no longer starve the manifest check.\n4. Manifest icons are accumulated and scored globally — no more first-manifest-wins. Also added priority-directory ordering (public/static/assets/Sources/etc. visited first) so the budget is spent in the right places.\n5. Added test/favicon-scanner.test.js with 30 fixture-based tests covering: scoring rules, manifest parsing (PWA + extension shape + maskable-only + missing src), Xcode appiconset, ghin-plus + usage-meter regression cases, projectNames tie-breaking, shallower-path tie-breaking, hashed-manifest-icon-beats-logo, two-manifests-larger-wins, node_modules skip, and the maxIconCandidates budget.\n\nVerified live against the real ghin-plus, usage-meter, and relay repos.",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["sidebar", "favicon", "review-followup"],
+      "tags": [
+        "sidebar",
+        "favicon",
+        "review-followup"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-20T12:00:00.000Z",
@@ -2140,7 +2412,10 @@
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["ui", "mobile"],
+      "tags": [
+        "ui",
+        "mobile"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
@@ -2149,11 +2424,15 @@
     {
       "id": "b9c34e12",
       "title": "Claude SDK: plan @anthropic-ai/sdk upgrade from 0.100.1 to 0.109.0",
-      "description": "We pin `@anthropic-ai/sdk` at exactly `0.100.1`; the library is now at `0.109.0` (9 minor versions). The upgrade path needs explicit planning because several streaming-surface changes land in this range:\n\n- **v0.106.0**: `system.message` streaming event type added. If our streaming handler throws on unknown event types rather than silently skipping, this will surface as an error in the streaming pipeline (`server/core/providers/claude-sdk.ts`).\n- **v0.106.0**: new refusal category \u2014 our refusal handling may need updating.\n- **v0.109.0**: Managed Agents event delta streaming \u2014 new streaming event shapes for agent deltas that could alter what we receive in the Claude API stream.\n- **v0.105.0 / v0.107.0**: `code_execution_20260120` and `20260318` web fetch/support tools \u2014 new tool types in the stream; verify we render them gracefully.\n- **`usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET`**: AGENTS.md flags this method will be renamed at stabilization. Verify it is still present under the same name in 0.109.0 before upgrading \u2014 silent degradation of rate-limit reporting if renamed without a feature-detect update.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md\n\nScope: audit streaming event handler in `claude-sdk.ts` against the 0.100.1\u21920.109.0 delta, check experimental method stability, then bump the pin.\n\nBucket 0 \u2014 priority 1.\n\n---\n\n**Reconciled 2026-07-01:** Pin bumped to `sdk@0.109.0` / `agent-sdk@^0.3.197` in commit `847e603` (that commit touched only package.json/lockfile, no `claude-sdk.ts` change). Post-hoc audit of the streaming handler confirms the bump is safe \u2014 `done` stands:\n- Handler is defensive at all three levels: `handleMessage` (`default:` debug-logs), `handleSystem` (`default:` debug-logs), and `handleStreamEvent` (if/else-if on `eventType`/block/delta with no `else` throw). Unknown `system.message`, managed-agent deltas, and new tool/refusal shapes are silently ignored \u2014 none can throw.\n- `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET` is still present under the same name and verified working (exercised by PR #22 tests). No rate-limit degradation.\n- New refusal category: `handleResult` treats `stop_reason` as an opaque string, so an unknown value just ends the turn normally.\n\nCorrection (2026-07-01, after digging the installed SDK types): the 'Managed Agents event delta streaming' line is bucket-1/no-op, NOT a risk and NOT 'ignored by handleStreamEvent' as first written. `BetaManagedAgentsDeltaEvent` lives in `@anthropic-ai/sdk` beta Sessions (hosted-agents REST surface, alongside deployments/vaults/memory-stores) which Relay does not consume \u2014 it never reaches the `claude-agent-sdk` query() stream Relay reads. Adopting it would mean taking on Anthropic's hosted managed-agents product: a large bucket-3 strategic decision, out of scope for this upgrade.\n\nSeparate genuine opportunity \u2014 a LOCAL nested subagent transcript is buildable: claude-agent-sdk exposes `forwardSubagentText: true` (default false) which forwards Task-tool subagent text/thinking as messages tagged `parent_tool_use_id`; `SDKPartialAssistantMessage` already carries `parent_tool_use_id`; and `listSubagents()`/`getSubagentMessages()` read subagent JSONL transcripts. Tracked separately if pursued.",
+      "description": "We pin `@anthropic-ai/sdk` at exactly `0.100.1`; the library is now at `0.109.0` (9 minor versions). The upgrade path needs explicit planning because several streaming-surface changes land in this range:\n\n- **v0.106.0**: `system.message` streaming event type added. If our streaming handler throws on unknown event types rather than silently skipping, this will surface as an error in the streaming pipeline (`server/core/providers/claude-sdk.ts`).\n- **v0.106.0**: new refusal category — our refusal handling may need updating.\n- **v0.109.0**: Managed Agents event delta streaming — new streaming event shapes for agent deltas that could alter what we receive in the Claude API stream.\n- **v0.105.0 / v0.107.0**: `code_execution_20260120` and `20260318` web fetch/support tools — new tool types in the stream; verify we render them gracefully.\n- **`usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET`**: AGENTS.md flags this method will be renamed at stabilization. Verify it is still present under the same name in 0.109.0 before upgrading — silent degradation of rate-limit reporting if renamed without a feature-detect update.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md\n\nScope: audit streaming event handler in `claude-sdk.ts` against the 0.100.1→0.109.0 delta, check experimental method stability, then bump the pin.\n\nBucket 0 — priority 1.\n\n---\n\n**Reconciled 2026-07-01:** Pin bumped to `sdk@0.109.0` / `agent-sdk@^0.3.197` in commit `847e603` (that commit touched only package.json/lockfile, no `claude-sdk.ts` change). Post-hoc audit of the streaming handler confirms the bump is safe — `done` stands:\n- Handler is defensive at all three levels: `handleMessage` (`default:` debug-logs), `handleSystem` (`default:` debug-logs), and `handleStreamEvent` (if/else-if on `eventType`/block/delta with no `else` throw). Unknown `system.message`, managed-agent deltas, and new tool/refusal shapes are silently ignored — none can throw.\n- `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET` is still present under the same name and verified working (exercised by PR #22 tests). No rate-limit degradation.\n- New refusal category: `handleResult` treats `stop_reason` as an opaque string, so an unknown value just ends the turn normally.\n\nCorrection (2026-07-01, after digging the installed SDK types): the 'Managed Agents event delta streaming' line is bucket-1/no-op, NOT a risk and NOT 'ignored by handleStreamEvent' as first written. `BetaManagedAgentsDeltaEvent` lives in `@anthropic-ai/sdk` beta Sessions (hosted-agents REST surface, alongside deployments/vaults/memory-stores) which Relay does not consume — it never reaches the `claude-agent-sdk` query() stream Relay reads. Adopting it would mean taking on Anthropic's hosted managed-agents product: a large bucket-3 strategic decision, out of scope for this upgrade.\n\nSeparate genuine opportunity — a LOCAL nested subagent transcript is buildable: claude-agent-sdk exposes `forwardSubagentText: true` (default false) which forwards Task-tool subagent text/thinking as messages tagged `parent_tool_use_id`; `SDKPartialAssistantMessage` already carries `parent_tool_use_id`; and `listSubagents()`/`getSubagentMessages()` read subagent JSONL transcripts. Tracked separately if pursued.",
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-0"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-0"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
@@ -2162,11 +2441,15 @@
     {
       "id": "f2a7d091",
       "title": "Claude: surface model-scoped weekly rate-limit windows in rate-limit UI",
-      "description": "Claude Agent SDK v0.3.191 added a `model_scoped` array to the usage response: per-model weekly limit windows each carrying `utilization`, `resetAt`, and `windowLabel`. This is separate from the existing flat `five_hour`/`seven_day` windows we already display.\n\nCurrently, our rate-limit display in the sidecar and settings page shows aggregate windows (`ProviderRateLimitStatus.windows[]`). The new `model_scoped` data would let us show per-model weekly headroom \u2014 useful for users running multiple models in the same project.\n\nAlso added: `seven_day_overage_included` on `SDKRateLimitInfo.rateLimitType` for per-model weekly usage limits. This field tells us whether the seven-day overage is included in the displayed utilization, improving the accuracy of how we label the bar.\n\nTouches: `server/core/providers/claude-sdk.ts` (rate limit parsing), `ProviderRateLimitStatus` type, and the sidecar rate-limit UI (`app/src/components/...`).\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.191\n\nBucket 2 \u2014 priority 2.\n\n---\n\n**Post-upgrade note (2026-07-01, commit `23aa4c0`):** The agent SDK is now bumped to 0.3.197, so `model_scoped` and `seven_day_overage_included` are present in the installed `sdk.d.ts` \u2014 no SDK bump needed to start this. **Field names in the paragraph above are wrong.** The actual installed shape is:\n```\nmodel_scoped?: { display_name: string; utilization: number | null; resets_at: string | null }[]\n```\ni.e. `display_name` (not `windowLabel`) and `resets_at` (not `resetAt`). It lives on `SDKControlGetUsageResponse.rate_limits` alongside `five_hour`/`seven_day` (also note the sibling `extra_usage` field). Our parser reads `resets_at`/`utilization` (0-100, divided by 100) in `probeUsageRateLimits`; extend `USAGE_RATE_LIMIT_WINDOW_KEYS`/that parser for the model_scoped array.",
+      "description": "Claude Agent SDK v0.3.191 added a `model_scoped` array to the usage response: per-model weekly limit windows each carrying `utilization`, `resetAt`, and `windowLabel`. This is separate from the existing flat `five_hour`/`seven_day` windows we already display.\n\nCurrently, our rate-limit display in the sidecar and settings page shows aggregate windows (`ProviderRateLimitStatus.windows[]`). The new `model_scoped` data would let us show per-model weekly headroom — useful for users running multiple models in the same project.\n\nAlso added: `seven_day_overage_included` on `SDKRateLimitInfo.rateLimitType` for per-model weekly usage limits. This field tells us whether the seven-day overage is included in the displayed utilization, improving the accuracy of how we label the bar.\n\nTouches: `server/core/providers/claude-sdk.ts` (rate limit parsing), `ProviderRateLimitStatus` type, and the sidecar rate-limit UI (`app/src/components/...`).\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.191\n\nBucket 2 — priority 2.\n\n---\n\n**Post-upgrade note (2026-07-01, commit `23aa4c0`):** The agent SDK is now bumped to 0.3.197, so `model_scoped` and `seven_day_overage_included` are present in the installed `sdk.d.ts` — no SDK bump needed to start this. **Field names in the paragraph above are wrong.** The actual installed shape is:\n```\nmodel_scoped?: { display_name: string; utilization: number | null; resets_at: string | null }[]\n```\ni.e. `display_name` (not `windowLabel`) and `resets_at` (not `resetAt`). It lives on `SDKControlGetUsageResponse.rate_limits` alongside `five_hour`/`seven_day` (also note the sibling `extra_usage` field). Our parser reads `resets_at`/`utilization` (0-100, divided by 100) in `probeUsageRateLimits`; extend `USAGE_RATE_LIMIT_WINDOW_KEYS`/that parser for the model_scoped array.",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
@@ -2175,11 +2458,15 @@
     {
       "id": "8e6b4a27",
       "title": "Claude: surface agent_id in permission prompts from background agents",
-      "description": "Claude Agent SDK v0.3.186 added `agent_id` to `can_use_tool` control requests and changed background-agent behavior: background agents now forward permission prompts to `canUseTool` instead of auto-denying.\n\nThis has two effects on Relay:\n1. Our permission-prompt UI will now receive `can_use_tool` requests from background agents that previously never surfaced. Volume of interactive permission requests may increase for multi-agent sessions.\n2. The `agent_id` field lets us identify which subagent is requesting a permission, enabling a richer permission UI (e.g. \"Agent `abc123` wants to use the bash tool\").\n\n`ProviderCapabilities` currently has no concept of agent identity on permission requests. Relay should:\n- Map `agent_id` through the permission control request flow in `claude-sdk.ts` and the `PermissionRequest` type.\n- Surface it in the `AskUserQuestionPanel` / permission banner so users see which agent is asking.\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.186\n\nBucket 2 \u2014 priority 2.\n\n---\n\n**Post-upgrade note (2026-07-01, commit `23aa4c0`):** The agent SDK is now bumped to 0.3.197, so effect #1 is **already live in production** \u2014 background-agent permission prompts now flow to `canUseTool` (no longer auto-denied) as of this commit, independent of any UI work here. Reframe: this is no longer 'enable a new path' but 'prompts are already surfacing untagged \u2014 add `agent_id` attribution.' `agent_id` is confirmed present on the can_use_tool control request (`sdk.d.ts`); our `CanUseTool` options type in `claude-sdk.ts` already declares an `agentID?` slot, so plumbing is partly wired. Bumping priority worth considering given the behavior is active.",
+      "description": "Claude Agent SDK v0.3.186 added `agent_id` to `can_use_tool` control requests and changed background-agent behavior: background agents now forward permission prompts to `canUseTool` instead of auto-denying.\n\nThis has two effects on Relay:\n1. Our permission-prompt UI will now receive `can_use_tool` requests from background agents that previously never surfaced. Volume of interactive permission requests may increase for multi-agent sessions.\n2. The `agent_id` field lets us identify which subagent is requesting a permission, enabling a richer permission UI (e.g. \"Agent `abc123` wants to use the bash tool\").\n\n`ProviderCapabilities` currently has no concept of agent identity on permission requests. Relay should:\n- Map `agent_id` through the permission control request flow in `claude-sdk.ts` and the `PermissionRequest` type.\n- Surface it in the `AskUserQuestionPanel` / permission banner so users see which agent is asking.\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.186\n\nBucket 2 — priority 2.\n\n---\n\n**Post-upgrade note (2026-07-01, commit `23aa4c0`):** The agent SDK is now bumped to 0.3.197, so effect #1 is **already live in production** — background-agent permission prompts now flow to `canUseTool` (no longer auto-denied) as of this commit, independent of any UI work here. Reframe: this is no longer 'enable a new path' but 'prompts are already surfacing untagged — add `agent_id` attribution.' `agent_id` is confirmed present on the can_use_tool control request (`sdk.d.ts`); our `CanUseTool` options type in `claude-sdk.ts` already declares an `agentID?` slot, so plumbing is partly wired. Bumping priority worth considering given the behavior is active.",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
@@ -2188,11 +2475,15 @@
     {
       "id": "3c1f9d48",
       "title": "Codex: handle safety-buffering visibility and faster-model metadata from app-server",
-      "description": "Codex CLI v0.142.2 release note: \"Apps can display richer safety-buffering UI using server-provided visibility and faster-model metadata.\" This means the Codex app-server now emits additional fields \u2014 safety-buffering visibility state and the identity/metadata of the faster model used for safety checks \u2014 that clients can surface in their UI.\n\nOur `server/core/providers/codex-app-server.ts` integrates directly with the Codex app-server JSON-RPC stream. We should:\n1. Identify the new message type(s) or new fields on existing messages carrying this data (inspect Codex source or wait for app-server protocol docs).\n2. Map any new capability fields through `ProviderCapabilities` (a `safetyBufferingVisible` flag and/or a `safetyModel` field) and expose them in the provider state broadcast.\n3. Optionally surface a subtle UI indicator when safety-buffering is active (similar to how we show pending-tool state).\n\nScope is small if the fields simply arrive on an existing event; larger if a new notification type is required.\n\nRef: github.com/openai/codex releases v0.142.2\n\nBucket 2 \u2014 priority 2.\n\n---\n\n**Kickback note (2026-07-08):** Not mechanical. The Codex app-server protocol for safety-buffering fields is not documented in the Relay codebase and the Codex binary is not available in the dev environment for inspection. The task step 1 ('identify the new message type(s)') requires research into Codex app-server source or release docs before any ProviderCapabilities wiring can be scoped. Needs human design/research before re-queuing as bucket-2.",
+      "description": "Codex CLI v0.142.2 release note: \"Apps can display richer safety-buffering UI using server-provided visibility and faster-model metadata.\" This means the Codex app-server now emits additional fields — safety-buffering visibility state and the identity/metadata of the faster model used for safety checks — that clients can surface in their UI.\n\nOur `server/core/providers/codex-app-server.ts` integrates directly with the Codex app-server JSON-RPC stream. We should:\n1. Identify the new message type(s) or new fields on existing messages carrying this data (inspect Codex source or wait for app-server protocol docs).\n2. Map any new capability fields through `ProviderCapabilities` (a `safetyBufferingVisible` flag and/or a `safetyModel` field) and expose them in the provider state broadcast.\n3. Optionally surface a subtle UI indicator when safety-buffering is active (similar to how we show pending-tool state).\n\nScope is small if the fields simply arrive on an existing event; larger if a new notification type is required.\n\nRef: github.com/openai/codex releases v0.142.2\n\nBucket 2 — priority 2.\n\n---\n\n**Kickback note (2026-07-08):** Not mechanical. The Codex app-server protocol for safety-buffering fields is not documented in the Relay codebase and the Codex binary is not available in the dev environment for inspection. The task step 1 ('identify the new message type(s)') requires research into Codex app-server source or release docs before any ProviderCapabilities wiring can be scoped. Needs human design/research before re-queuing as bucket-2.",
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "codex", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "codex",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
@@ -2201,24 +2492,33 @@
     {
       "id": "a5d82c63",
       "title": "Claude: design session branching via rewind_conversation primitive",
-      "description": "Claude Agent SDK v0.3.186 added a `rewind_conversation` control request that rewinds a conversation to a previous point with durable resume-anchor support. This is a genuine new session-management primitive.\n\n**Would've been bucket-2 if Relay had a provider-agnostic session-branching abstraction.** This is the flag: if Relay defined a provider-neutral \"branch session\" concept (a capability-shaped `sessionBranching` flag in `ProviderCapabilities`, a `branchSession(anchorId)` method on the provider driver contract), this would be a near-mechanical implementation task. Today it's bucket-3 because that abstraction doesn't exist.\n\nScope of this design task:\n1. Define what \"session branching\" means in Relay terms: user picks a point in history, Relay creates a sibling managed session resumed from that anchor.\n2. Decide where the branch entry-point lives in the UI (message context menu? chat header action?).\n3. Map `rewind_conversation` onto a provider-neutral `ProviderCapabilities.sessionBranching` flag so the UI only renders the control when the active provider supports it.\n4. Define the Codex equivalent if any (or mark as Claude-only pending Codex support).\n5. Consider whether this overlaps with the existing Spin Off flow (tasks `8092b659`, `6e0e1f44`).\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.186\n\nBucket 3 (passes chase test: new primitive to generalize across providers) \u2014 priority 3.",
+      "description": "Claude Agent SDK v0.3.186 added a `rewind_conversation` control request that rewinds a conversation to a previous point with durable resume-anchor support. This is a genuine new session-management primitive.\n\n**Would've been bucket-2 if Relay had a provider-agnostic session-branching abstraction.** This is the flag: if Relay defined a provider-neutral \"branch session\" concept (a capability-shaped `sessionBranching` flag in `ProviderCapabilities`, a `branchSession(anchorId)` method on the provider driver contract), this would be a near-mechanical implementation task. Today it's bucket-3 because that abstraction doesn't exist.\n\nScope of this design task:\n1. Define what \"session branching\" means in Relay terms: user picks a point in history, Relay creates a sibling managed session resumed from that anchor.\n2. Decide where the branch entry-point lives in the UI (message context menu? chat header action?).\n3. Map `rewind_conversation` onto a provider-neutral `ProviderCapabilities.sessionBranching` flag so the UI only renders the control when the active provider supports it.\n4. Define the Codex equivalent if any (or mark as Claude-only pending Codex support).\n5. Consider whether this overlaps with the existing Spin Off flow (tasks `8092b659`, `6e0e1f44`).\n\nRef: claude-agent-sdk-typescript CHANGELOG v0.3.186\n\nBucket 3 (passes chase test: new primitive to generalize across providers) — priority 3.\n\n---\n**Codex update (2026-08-03):** Codex 0.146.0 (released 2026-07-29) ships thread forking: \"Fork threads with paginated history, including temporary forks that do not appear in thread listings.\" This is the Codex-side equivalent this task asked for. The design question \"Define the Codex equivalent if any\" now has an answer — Codex has a native fork primitive, even if it's exposed differently from Claude's `rewind_conversation` anchor model. The abstraction design should account for both mechanisms.",
       "status": "open",
       "priority": 3,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-3"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-3"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-06-30T00:00:00.000Z",
-      "updatedAt": "2026-06-30T00:00:00.000Z"
+      "updatedAt": "2026-08-03T00:00:00.000Z"
     },
     {
       "id": "803fe57b",
       "title": "Nested subagent activity view (provider-agnostic: Claude + Codex)",
-      "description": "Surface nested subagent activity \u2014 a parent agent's spawned children \u2014 under the parent tool-use/turn, provider-agnostically. Both providers now support the concept via different mechanisms, so this is cross-provider normalization, not a Claude-only feature.\n\nApproach: add a `ProviderCapabilities.nestedAgentActivity` flag; the UI renders a nested/collapsible activity+transcript view only when the active provider declares it. No provider-specific logic in the UI (capability-driven, per architecture invariants).\n\nClaude (claude-agent-sdk): set `forwardSubagentText: true` (default false) to forward subagent text/thinking as messages tagged `parent_tool_use_id`; `SDKPartialAssistantMessage` already carries `parent_tool_use_id`. Group streaming state by it in `claude-sdk.ts` (today it builds one flat pending message). Transcript fallback: `listSubagents()` / `getSubagentMessages()` read `~/.claude/projects/<dir>/<sessionId>/subagents/agent-<id>.jsonl`.\n\nCodex (app-server): subagents are separate threads linked by `parentThreadId` / `ancestorThreadId` (with `agentNickname`/`agentRole` on subagent threads, under `sessionId` as tree root). Live + historical activity via the `subAgentActivity` thread item (PR #27007, merged 2026-06-09, completion-only: toolCallId, timestamp, affected thread, canonical agent path, kind = started|interacted|interrupted). Full child content read via `thread/read`. `multiAgentMode` (explicitRequestOnly|proactive; PR #28792, @experimental) gates proactive spawning.\n\nDesign cost / caveats:\n- Mechanism mismatch is the real work: Claude gives inline forwarded text; Codex gives lifecycle activity + a separate thread to fetch. The shared abstraction must accommodate both an 'inline stream' and a 'go read the child' model.\n- Experimental flags: Codex `ancestorThreadId` needs `capabilities.experimentalApi`; `multiAgentMode` is @experimental. `subAgentActivity` itself is not flagged.\n- Version check: Relay pins Codex 0.142.4; confirm these PRs (merged 2026-06-09 / 2026-06-19) are in that build before scoping.\n\nData plumbing (parent_tool_use_id threading, thread reads) largely exists; the new part is the nested-view UI \u2014 would've been bucket-2 if Relay already had a nested-transcript UI component.\n\nSources: codex app-server README; openai/codex PR #27007 (subAgentActivity), #28792 (multiAgentMode). Claude: claude-agent-sdk sdk.d.ts \u2014 forwardSubagentText, SDKPartialAssistantMessage.parent_tool_use_id, getSubagentMessages/listSubagents.\n\nBucket 3 \u2014 priority 3.",
+      "description": "Surface nested subagent activity — a parent agent's spawned children — under the parent tool-use/turn, provider-agnostically. Both providers now support the concept via different mechanisms, so this is cross-provider normalization, not a Claude-only feature.\n\nApproach: add a `ProviderCapabilities.nestedAgentActivity` flag; the UI renders a nested/collapsible activity+transcript view only when the active provider declares it. No provider-specific logic in the UI (capability-driven, per architecture invariants).\n\nClaude (claude-agent-sdk): set `forwardSubagentText: true` (default false) to forward subagent text/thinking as messages tagged `parent_tool_use_id`; `SDKPartialAssistantMessage` already carries `parent_tool_use_id`. Group streaming state by it in `claude-sdk.ts` (today it builds one flat pending message). Transcript fallback: `listSubagents()` / `getSubagentMessages()` read `~/.claude/projects/<dir>/<sessionId>/subagents/agent-<id>.jsonl`.\n\nCodex (app-server): subagents are separate threads linked by `parentThreadId` / `ancestorThreadId` (with `agentNickname`/`agentRole` on subagent threads, under `sessionId` as tree root). Live + historical activity via the `subAgentActivity` thread item (PR #27007, merged 2026-06-09, completion-only: toolCallId, timestamp, affected thread, canonical agent path, kind = started|interacted|interrupted). Full child content read via `thread/read`. `multiAgentMode` (explicitRequestOnly|proactive; PR #28792, @experimental) gates proactive spawning.\n\nDesign cost / caveats:\n- Mechanism mismatch is the real work: Claude gives inline forwarded text; Codex gives lifecycle activity + a separate thread to fetch. The shared abstraction must accommodate both an 'inline stream' and a 'go read the child' model.\n- Experimental flags: Codex `ancestorThreadId` needs `capabilities.experimentalApi`; `multiAgentMode` is @experimental. `subAgentActivity` itself is not flagged.\n- Version check: Relay pins Codex 0.142.4; confirm these PRs (merged 2026-06-09 / 2026-06-19) are in that build before scoping.\n\nData plumbing (parent_tool_use_id threading, thread reads) largely exists; the new part is the nested-view UI — would've been bucket-2 if Relay already had a nested-transcript UI component.\n\nSources: codex app-server README; openai/codex PR #27007 (subAgentActivity), #28792 (multiAgentMode). Claude: claude-agent-sdk sdk.d.ts — forwardSubagentText, SDKPartialAssistantMessage.parent_tool_use_id, getSubagentMessages/listSubagents.\n\nBucket 3 — priority 3.",
       "status": "open",
       "priority": 3,
       "type": "task",
-      "tags": ["provider-watch", "claude", "codex", "bucket-3"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "codex",
+        "bucket-3"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-01T16:15:00.000Z",
@@ -2227,11 +2527,15 @@
     {
       "id": "c4e91a73",
       "title": "Anthropic SDK: evaluated_permission gating and idle stop_reason (0.111.0 heads-up)",
-      "description": "Two contract changes land in `@anthropic-ai/sdk` 0.111.0 (2026-07-10) that Relay must audit before the next SDK pin bump:\n\n1. **`evaluated_permission` gating**: Session tool calls are now gated on an `evaluated_permission` result before they execute. This is a semantic change to the SDK's tool-call flow \u2014 the permission decision is no longer purely client-side. Relay's `canUseTool` callback and permission-request plumbing in `claude-sdk.ts` must be verified to still work correctly under this model.\n\n2. **`idle` stop_reason**: The server can now return `stop_reason: 'idle'` to bound a session turn that ends because the session went idle (rather than completing or being interrupted). Our `handleResult` in `claude-sdk.ts` treats `stop_reason` as an opaque string and ends the turn normally \u2014 this is safe \u2014 but we should verify the resulting turn state is emitted correctly (not as an error) and that the session is not left in a hung state.\n\nNote: `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET` is still unaffected per 0.111.0 changelog; still safe to rely on until stabilization rename.\n\nRelated: prior SDK upgrade task `b9c34e12` (done, covered 0.100.1\u21920.109.0). This task covers 0.109.0\u21920.111.0 delta.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md (v0.110.0, v0.111.0)\n\nBucket 0 \u2014 priority 1.",
+      "description": "Two contract changes land in `@anthropic-ai/sdk` 0.111.0 (2026-07-10) that Relay must audit before the next SDK pin bump:\n\n1. **`evaluated_permission` gating**: Session tool calls are now gated on an `evaluated_permission` result before they execute. This is a semantic change to the SDK's tool-call flow — the permission decision is no longer purely client-side. Relay's `canUseTool` callback and permission-request plumbing in `claude-sdk.ts` must be verified to still work correctly under this model.\n\n2. **`idle` stop_reason**: The server can now return `stop_reason: 'idle'` to bound a session turn that ends because the session went idle (rather than completing or being interrupted). Our `handleResult` in `claude-sdk.ts` treats `stop_reason` as an opaque string and ends the turn normally — this is safe — but we should verify the resulting turn state is emitted correctly (not as an error) and that the session is not left in a hung state.\n\nNote: `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET` is still unaffected per 0.111.0 changelog; still safe to rely on until stabilization rename.\n\nRelated: prior SDK upgrade task `b9c34e12` (done, covered 0.100.1→0.109.0). This task covers 0.109.0→0.111.0 delta.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md (v0.110.0, v0.111.0)\n\nBucket 0 — priority 1.",
       "status": "open",
       "priority": 1,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-0"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-0"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-13T00:00:00.000Z",
@@ -2240,11 +2544,15 @@
     {
       "id": "d7f03b28",
       "title": "Codex: add `writes` approval mode to ProviderCapabilities.runtimeModes",
-      "description": "Codex CLI v0.144.0 (2026-07-09) added a `writes` app-approval mode: declared read-only tool calls are auto-allowed; only write-access tool calls prompt for approval. This is a third `approvalPolicy` value alongside the existing `on-request` and `never`.\n\nRelay's `resolveApprovalPolicy()` in `server/core/providers/codex-app-server.ts` currently maps `full-access \u2192 'never'` and everything else \u2192 `'on-request'`. The `writes` mode has no Relay representation:\n\n1. Add `'writes-only'` (or similar Relay-canonical name) to `ProviderRuntimeMode` and map it to Codex `approvalPolicy: 'writes'` in `resolveApprovalPolicy()`.\n2. Add an entry to `ProviderCapabilities.runtimeModes` for Codex so the UI renders the new option in the runtime-mode picker (label, description, icon \u2014 driven by capability metadata, never hardcoded in the UI).\n3. Verify the Codex app-server actually accepts `writes` on the `turn/start` or `session/init` RPC \u2014 confirm the field name from the codex source or app-server protocol docs.\n4. Update `ProviderRuntimeMode` union type in `server/core/types.ts`, the DB column values if needed, and any downstream switch exhaustion checks.\n\nRef: https://github.com/openai/codex/releases/tag/v0.144.0\n\nBucket 2 \u2014 priority 2.",
+      "description": "Codex CLI v0.144.0 (2026-07-09) added a `writes` app-approval mode: declared read-only tool calls are auto-allowed; only write-access tool calls prompt for approval. This is a third `approvalPolicy` value alongside the existing `on-request` and `never`.\n\nRelay's `resolveApprovalPolicy()` in `server/core/providers/codex-app-server.ts` currently maps `full-access → 'never'` and everything else → `'on-request'`. The `writes` mode has no Relay representation:\n\n1. Add `'writes-only'` (or similar Relay-canonical name) to `ProviderRuntimeMode` and map it to Codex `approvalPolicy: 'writes'` in `resolveApprovalPolicy()`.\n2. Add an entry to `ProviderCapabilities.runtimeModes` for Codex so the UI renders the new option in the runtime-mode picker (label, description, icon — driven by capability metadata, never hardcoded in the UI).\n3. Verify the Codex app-server actually accepts `writes` on the `turn/start` or `session/init` RPC — confirm the field name from the codex source or app-server protocol docs.\n4. Update `ProviderRuntimeMode` union type in `server/core/types.ts`, the DB column values if needed, and any downstream switch exhaustion checks.\n\nRef: https://github.com/openai/codex/releases/tag/v0.144.0\n\nBucket 2 — priority 2.",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "codex", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "codex",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-13T00:00:00.000Z",
@@ -2253,11 +2561,15 @@
     {
       "id": "e2a81c94",
       "title": "Claude: expose auto mode as a runtime-mode capability option",
-      "description": "Claude Code CLI v2.1.207 (2026-07-11) made auto mode generally available without the `CLAUDE_CODE_ENABLE_AUTO_MODE` env-var opt-in on Bedrock, Vertex AI, and Foundry. It can be disabled via `disableAutoMode` in `~/.claude/settings.json`.\n\nAuto mode is a distinct permission-management model: a safety classifier automatically approves or rejects each tool call without user prompts \u2014 between the current `approval-required` (prompt everything) and `full-access` (allow everything) modes in Relay's `ProviderRuntimeMode`.\n\nCurrently Relay has no representation for auto mode:\n\n1. **Determine SDK surface**: check whether the Claude Agent SDK exposes auto mode as a `permissionMode` value (likely `permissionMode: 'auto'`) or whether it requires a separate session argument / settings injection. The Claude Code CLI docs and SDK changelog are the reference.\n2. **Add to `ProviderCapabilities`**: add `autoMode` to `ProviderCapabilities.runtimeModes` (or as a boolean `autoMode` capability flag) for the Claude driver. Scope the flag to platforms where it is actually supported (Bedrock, Vertex, Foundry \u2014 not necessarily the standard API).\n3. **Provider driver**: map the new Relay runtime mode to the correct SDK arg in `claude-sdk.ts`.\n4. **UI**: the runtime-mode picker already renders from `ProviderCapabilities.runtimeModes` metadata \u2014 ensure label and description copy are added.\n5. **`disableAutoMode` setting**: if users have this set, Relay should not offer auto mode as an option (or surface a warning). Consider reading from `~/.claude/settings.json` in the provider version probe and reflecting it in capabilities.\n\nNote: `permissionMode: 'manual'` is now an accepted alias for `'default'` in the SDK (v0.3.200) \u2014 no change needed, `'default'` still works. The auto mode capability is the new surface.\n\nRef: https://github.com/anthropics/claude-code/releases/tag/v2.1.207, claude-agent-sdk-typescript CHANGELOG v0.3.200\n\nBucket 2 \u2014 priority 2.",
+      "description": "Claude Code CLI v2.1.207 (2026-07-11) made auto mode generally available without the `CLAUDE_CODE_ENABLE_AUTO_MODE` env-var opt-in on Bedrock, Vertex AI, and Foundry. It can be disabled via `disableAutoMode` in `~/.claude/settings.json`.\n\nAuto mode is a distinct permission-management model: a safety classifier automatically approves or rejects each tool call without user prompts — between the current `approval-required` (prompt everything) and `full-access` (allow everything) modes in Relay's `ProviderRuntimeMode`.\n\nCurrently Relay has no representation for auto mode:\n\n1. **Determine SDK surface**: check whether the Claude Agent SDK exposes auto mode as a `permissionMode` value (likely `permissionMode: 'auto'`) or whether it requires a separate session argument / settings injection. The Claude Code CLI docs and SDK changelog are the reference.\n2. **Add to `ProviderCapabilities`**: add `autoMode` to `ProviderCapabilities.runtimeModes` (or as a boolean `autoMode` capability flag) for the Claude driver. Scope the flag to platforms where it is actually supported (Bedrock, Vertex, Foundry — not necessarily the standard API).\n3. **Provider driver**: map the new Relay runtime mode to the correct SDK arg in `claude-sdk.ts`.\n4. **UI**: the runtime-mode picker already renders from `ProviderCapabilities.runtimeModes` metadata — ensure label and description copy are added.\n5. **`disableAutoMode` setting**: if users have this set, Relay should not offer auto mode as an option (or surface a warning). Consider reading from `~/.claude/settings.json` in the provider version probe and reflecting it in capabilities.\n\nNote: `permissionMode: 'manual'` is now an accepted alias for `'default'` in the SDK (v0.3.200) — no change needed, `'default'` still works. The auto mode capability is the new surface.\n\nRef: https://github.com/anthropics/claude-code/releases/tag/v2.1.207, claude-agent-sdk-typescript CHANGELOG v0.3.200\n\nBucket 2 — priority 2.",
       "status": "done",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-13T00:00:00.000Z",
@@ -2266,11 +2578,15 @@
     {
       "id": "ffbc884b",
       "title": "Claude SDK: surface `blocked` state from workflow_agent events in agents view",
-      "description": "**What changed**: SDK 0.3.199 added a `blocked` field to `workflow_agent` progress events, set to `true` when an agent was blocked by the auto-mode safety classifier.\n\n**Bucket**: 2 (capability-declaration)\n\n**ProviderCapabilities / abstraction**: No new `ProviderCapabilities` field required \u2014 this is new event data in the existing `workflow_agent` event shape. Touch point: the live activity stream in `claude-sdk.ts` that processes `workflow_agent` events, and the agents sidecar component that renders agent rows.\n\n**UI control**: Agents sidecar view should show a `blocked` indicator (badge, icon, or status label) on affected agent rows so users know an agent stalled on the safety classifier. Related to open task `803fe57b` (nested subagent activity view); consider landing as a prerequisite detail of that redesign.\n\n**Scope estimate**: Small. (1) Parse `blocked` field in the `workflow_agent` event handler in `claude-sdk.ts`. (2) Forward it through the `AgentActivity` / `ActivityMessage` type. (3) Render a `ShieldAlert` icon or equivalent on blocked agent rows in the sidecar.\n\n**Changelog ref**: @anthropic-ai/claude-agent-sdk 0.3.199\n\n---\n\n**Kickback note (2026-07-22):** Two blockers make this not mechanical: (1) The installed SDK is pinned at 0.3.197; `workflow_agent` events were added in 0.3.199, so there is no event type to handle in the current codebase. (2) The sidecar has no agents tab today \u2014 `SidecarTab = 'tasks' | 'files' | 'plan' | 'context' | 'brief' | 'review'` \u2014 so there is no UI surface to render blocked agent rows. Both the SDK upgrade and an agents sidecar view are prerequisites. Recommend pairing with task `803fe57b` (nested subagent activity design) once that design lands.",
+      "description": "**What changed**: SDK 0.3.199 added a `blocked` field to `workflow_agent` progress events, set to `true` when an agent was blocked by the auto-mode safety classifier.\n\n**Bucket**: 2 (capability-declaration)\n\n**ProviderCapabilities / abstraction**: No new `ProviderCapabilities` field required — this is new event data in the existing `workflow_agent` event shape. Touch point: the live activity stream in `claude-sdk.ts` that processes `workflow_agent` events, and the agents sidecar component that renders agent rows.\n\n**UI control**: Agents sidecar view should show a `blocked` indicator (badge, icon, or status label) on affected agent rows so users know an agent stalled on the safety classifier. Related to open task `803fe57b` (nested subagent activity view); consider landing as a prerequisite detail of that redesign.\n\n**Scope estimate**: Small. (1) Parse `blocked` field in the `workflow_agent` event handler in `claude-sdk.ts`. (2) Forward it through the `AgentActivity` / `ActivityMessage` type. (3) Render a `ShieldAlert` icon or equivalent on blocked agent rows in the sidecar.\n\n**Changelog ref**: @anthropic-ai/claude-agent-sdk 0.3.199\n\n---\n\n**Kickback note (2026-07-22):** Two blockers make this not mechanical: (1) The installed SDK is pinned at 0.3.197; `workflow_agent` events were added in 0.3.199, so there is no event type to handle in the current codebase. (2) The sidecar has no agents tab today — `SidecarTab = 'tasks' | 'files' | 'plan' | 'context' | 'brief' | 'review'` — so there is no UI surface to render blocked agent rows. Both the SDK upgrade and an agents sidecar view are prerequisites. Recommend pairing with task `803fe57b` (nested subagent activity design) once that design lands.",
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-06T00:00:00.000Z",
@@ -2283,7 +2599,11 @@
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-06T00:00:00.000Z",
@@ -2296,7 +2616,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "providers", "ui"],
+      "tags": [
+        "mcp",
+        "providers",
+        "ui"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2309,7 +2633,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "providers", "settings"],
+      "tags": [
+        "mcp",
+        "providers",
+        "settings"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2322,7 +2650,10 @@
       "status": "done",
       "priority": 1,
       "type": "epic",
-      "tags": ["mcp", "providers"],
+      "tags": [
+        "mcp",
+        "providers"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2335,7 +2666,10 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "auth"],
+      "tags": [
+        "mcp",
+        "auth"
+      ],
       "parent": "c3e5a7b9",
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2348,7 +2682,10 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "project-settings"],
+      "tags": [
+        "mcp",
+        "project-settings"
+      ],
       "parent": "c3e5a7b9",
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2361,7 +2698,10 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "providers"],
+      "tags": [
+        "mcp",
+        "providers"
+      ],
       "parent": "c3e5a7b9",
       "blockedBy": [],
       "createdAt": "2026-07-14T00:00:00.000Z",
@@ -2374,9 +2714,17 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "tests", "review"],
+      "tags": [
+        "mcp",
+        "tests",
+        "review"
+      ],
       "parent": "c3e5a7b9",
-      "blockedBy": ["d4f6b8c0", "e5a7c9d1", "f6b8d0e2"],
+      "blockedBy": [
+        "d4f6b8c0",
+        "e5a7c9d1",
+        "f6b8d0e2"
+      ],
       "createdAt": "2026-07-14T00:00:00.000Z",
       "updatedAt": "2026-07-14T00:00:00.000Z"
     },
@@ -2387,7 +2735,11 @@
       "status": "done",
       "priority": 1,
       "type": "task",
-      "tags": ["mcp", "providers", "review"],
+      "tags": [
+        "mcp",
+        "providers",
+        "review"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-15T00:00:00.000Z",
@@ -2400,7 +2752,11 @@
       "status": "done",
       "priority": 1,
       "type": "bug",
-      "tags": ["mcp", "providers", "state"],
+      "tags": [
+        "mcp",
+        "providers",
+        "state"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-15T00:00:00.000Z",
@@ -2413,7 +2769,11 @@
       "status": "open",
       "priority": 1,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-0"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-0"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
@@ -2426,7 +2786,11 @@
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
@@ -2435,15 +2799,19 @@
     {
       "id": "f8c1a047",
       "title": "Claude Agent SDK: surface subagent_type and subagent_retry in agents sidecar",
-      "description": "SDK 0.3.214 adds two new fields to `tool_progress` events:\n- `subagent_type`: identifies what kind of subagent is running.\n- `subagent_retry`: whether this is a retry of a previously failed tool call.\n\nRelay's agents sidecar panel (see also open task `ffbc884b` for the related `blocked` field) shows live agent activity from `workflow_agent` and `tool_progress` events. These fields can enrich it:\n- Show subagent-type labels on agent rows instead of generic identifiers.\n- Show a retry indicator (badge or icon) on retried tool calls.\n\nTouch points:\n1. `claude-sdk.ts`: parse `subagent_type` and `subagent_retry` from `tool_progress` events and forward through `AgentActivity`.\n2. Agents sidecar component: render type labels and retry indicator.\n\nCoordinate with `ffbc884b` (blocked field) — consider landing together as a single sidecar-enrichment pass.\n\nScope: small (~2–3h including UI).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214",
+      "description": "SDK 0.3.214 adds two new fields to `tool_progress` events:\n- `subagent_type`: identifies what kind of subagent is running.\n- `subagent_retry`: whether this is a retry of a previously failed tool call.\n\nRelay's agents sidecar panel (see also open task `ffbc884b` for the related `blocked` field) shows live agent activity from `workflow_agent` and `tool_progress` events. These fields can enrich it:\n- Show subagent-type labels on agent rows instead of generic identifiers.\n- Show a retry indicator (badge or icon) on retried tool calls.\n\nTouch points:\n1. `claude-sdk.ts`: parse `subagent_type` and `subagent_retry` from `tool_progress` events and forward through `AgentActivity`.\n2. Agents sidecar component: render type labels and retry indicator.\n\nCoordinate with `ffbc884b` (blocked field) — consider landing together as a single sidecar-enrichment pass.\n\nScope: small (~2–3h including UI).\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.214\n\n---\n**Kicked back 2026-07-29**: Not mechanical. `SidecarTab` union in `app/src/stores/sidecar-store.ts` has no `\"agents\"` tab — the agents sidecar view does not exist as a discrete tab. Same blocker as `ffbc884b`. This task needs a design decision on where/how to surface subagent-type and retry information before any implementation can proceed.",
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
-      "updatedAt": "2026-07-20T00:00:00.000Z"
+      "updatedAt": "2026-07-29T00:00:00.000Z"
     },
     {
       "id": "9d3e6b82",
@@ -2452,11 +2820,168 @@
       "status": "open",
       "priority": 2,
       "type": "task",
-      "tags": ["provider-watch", "claude", "bucket-2"],
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
       "parent": null,
       "blockedBy": [],
       "createdAt": "2026-07-20T00:00:00.000Z",
       "updatedAt": "2026-07-20T00:00:00.000Z"
+    },
+    {
+      "id": "a1f3e820",
+      "title": "Anthropic SDK: handle model_context_window_exceeded stop reason",
+      "description": "SDK 0.114.0 (2026-07-23) adds a new stop reason value: `model_context_window_exceeded`. This is returned when a turn ends because the context window is full, as distinct from `end_turn` (model chose to stop) or `max_tokens` (output token cap hit).\n\nRelay's `handleResult` in `server/core/providers/claude-sdk.ts` processes stop reasons. Without explicit handling, a session that hit the context limit shows as a normal completed turn rather than surfacing a \"context window exceeded\" error.\n\nNeeded:\n1. Handle `model_context_window_exceeded` in `handleResult` (or wherever stop reasons are mapped to session events) and emit a distinct error/warning state.\n2. Surface it in the UI — either an inline message banner or a modified turn-end indicator — so the user knows the session cannot continue without compacting or starting over.\n3. Check JSONL replay: if this stop reason appears in transcript, ensure it renders consistently.\n\nScope: small–medium (~2–3h). Touch points: `claude-sdk.ts`, `SessionHistoryEntry`/`ChatMessage` if a new event type is needed, and the chat message renderer.\n\nBucket 0 — priority 1.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md (v0.114.0)",
+      "status": "open",
+      "priority": 1,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-0"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "b2c4d951",
+      "title": "Anthropic SDK: handle tool_change events and tool add/remove message blocks",
+      "description": "SDK 0.115.0 (2026-07-24) introduces a new streaming event type (`tool_change`) and new message block shapes for tool addition and removal in assistant messages, representing dynamic tool management during a conversation.\n\nRelay processes assistant message streams in `server/core/providers/claude-sdk.ts` and replays JSONL transcripts via the Claude transcript parser. If either path encounters a `tool_change` event or a tool-addition/removal block without a handler, the live stream could silently drop the block (content loss) or throw on any exhaustiveness check; JSONL replay would similarly fail.\n\nNeeded:\n1. In `claude-sdk.ts`, handle `tool_change` in the streaming event dispatcher — at minimum a no-op default that doesn't throw; ideally propagate as a system activity item.\n2. In the JSONL parser, handle tool-addition/removal block types without crashing.\n3. Decide whether these blocks warrant a visible UI row (e.g., \"Tools updated mid-session\") or silent handling is sufficient for the first pass.\n\nScope: small–medium. Touch points: `claude-sdk.ts` streaming handler, JSONL parser, optionally the chat message renderer.\n\nBucket 0 — priority 1.\n\nRef: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md (v0.115.0)",
+      "status": "open",
+      "priority": 1,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-0"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "c3d5f062",
+      "title": "Claude Agent SDK: parse tool_result_meta for accurate denied/interrupted/cancelled display",
+      "description": "SDK 0.3.216 adds a `tool_result_meta` sidecar to user messages carrying `non_execution_kind` (`'denied'`, `'interrupted'`, `'cancelled'`) and `user_feedback` for tool results that did not execute normally.\n\nCurrently Relay's transcript display must infer non-execution from result text content (string-matching prose). The new sidecar provides machine-readable classification at the protocol level.\n\nNeeded:\n1. Parse `tool_result_meta` from user messages in `claude-sdk.ts` and forward through `SessionHistoryEntry` / `ChatMessage` (a new optional `toolResultMeta?: { nonExecutionKind?: string; userFeedback?: string }` field).\n2. In the JSONL replay path, extract the same field.\n3. Update the tool-result renderer to show a distinct visual indicator (badge or label) for denied, interrupted, or cancelled tool results.\n\nCross-provider normalization opportunity: if Codex gains a parallel field, the shared `ChatMessage` type already carries it.\n\nScope: small (~2h). Touch points: `claude-sdk.ts`, `SessionHistoryEntry`/`ChatMessage` type, JSONL parser, tool-result renderer.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.216",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "d4e6a173",
+      "title": "Claude Agent SDK: use canonicalModel+provider from per-turn modelUsage for model tracking",
+      "description": "SDK 0.3.218 adds `canonicalModel` and `provider` fields to each `modelUsage` entry in the turn result message. Previously `modelUsage` carried only token counts per model; now each entry identifies the exact model ID and provider used for that turn.\n\nRelay currently tracks `lastTurnModel` from SDK info (`resolvedModel` / `inferClaudeModelIdFromSdkInfo`) to detect mid-session model switches. These new fields provide the same information more authoritatively, directly from the billing-level result.\n\nNeeded:\n1. In `claude-sdk.ts`, read `canonicalModel` + `provider` from `modelUsage` entries in the turn result and use them to update `lastTurnModel` (replacing or supplementing the current SDK-info inference).\n2. Verify that cost attribution in the cost-estimation path can use `canonicalModel` to look up the correct rate table — this resolves potential mispricing when alias model IDs differ from canonical IDs.\n3. No new ProviderCapabilities flag needed — this is a data-quality improvement to existing tracking.\n\nScope: small (~1–2h). Touch points: `claude-sdk.ts` result handler, cost estimation logic.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.218",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "e5f7b284",
+      "title": "Claude Agent SDK: expose cancel_queued capability in session interrupt flow",
+      "description": "SDK 0.3.219 adds opt-in `cancel_queued` to the interrupt control request, gated by capability flag `interrupt_cancel_queued_v1`. When set, interrupting a session also cancels any messages that were queued and waiting to dispatch — not just the currently-running turn.\n\nRelay's session stop/cancel path (initiated by the UI stop button) calls `interrupt()` on the SDK session. Without `cancel_queued`, queued messages in a multi-turn pipeline continue executing after the interrupt, which is surprising when users press stop expecting everything to halt.\n\nNeeded:\n1. Check whether the active session advertises `interrupt_cancel_queued_v1` from the capability handshake.\n2. If present, set `cancel_queued: true` on the `interrupt()` call in `claude-sdk.ts`.\n3. Add `interruptCancelQueued?: boolean` to `ProviderCapabilities` so the UI can surface a choice between \"stop current turn\" and \"stop and clear queue\" if desired.\n\nScope: small (~1–2h). Touch points: `claude-sdk.ts` (interrupt call), `ProviderCapabilities` type.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.219",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "f6a8c395",
+      "title": "Claude Agent SDK: surface fast_mode_disabled_reason in fast-mode UI",
+      "description": "SDK 0.3.219 adds `fast_mode_disabled_reason` to turn result and session init messages. This string field explains why fast mode is unavailable (e.g., organization policy, plan tier, model incompatibility). Previously the UI could only show that fast mode was off, with no explanation.\n\nNeeded:\n1. Parse `fast_mode_disabled_reason` from result and init messages in `claude-sdk.ts` and forward it through the provider state broadcast.\n2. Surface the reason as a tooltip or subtitle on the disabled fast-mode toggle so users know whether they can address it or not.\n\nScope: small (~1h). Touch points: `claude-sdk.ts`, `ProviderGlobalState` or instance info type, fast-mode UI component.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.219",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "07b9d406",
+      "title": "Claude: expose sandbox.network.strictAllowlist as a session capability option",
+      "description": "CLI 2.1.219 and Agent SDK 0.3.219 add `sandbox.network.strictAllowlist` to session settings. When enabled, sandboxed commands are denied access to any host not in the `sandbox.network.allowedHosts` allowlist without prompting — giving operators deterministic network isolation for agent sessions.\n\nRelay currently exposes sandbox settings from `ProviderCapabilities` (permission mode, etc.) but has no concept of network-level sandboxing.\n\nNeeded:\n1. Add a `networkStrictAllowlist?: boolean` (or a `sandboxNetwork` sub-object) to `ProviderCapabilities` for the Claude driver.\n2. Expose it as a toggleable session option in session creation / project settings.\n3. Thread the setting through to the SDK session-start args in `claude-sdk.ts`.\n4. If `sandbox.network.allowedHosts` is also configurable, consider a companion list field.\n\nScope: medium (~2–4h). Touch points: `ProviderCapabilities` type, `claude-sdk.ts`, project or global settings UI, session creation.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-code CHANGELOG v2.1.219, @anthropic-ai/claude-agent-sdk CHANGELOG v0.3.219",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "18ca0517",
+      "title": "Claude: surface mcp_server_errors from headless init event in MCP status UI",
+      "description": "CLI 2.1.219 adds `mcp_server_errors` to the headless stream-json init event — an array of `--mcp-config` entries that failed config validation and were skipped at startup.\n\nRelay launches Claude sessions in headless mode and processes the stream-json init event in `claude-sdk.ts`. The MCP management UI shows configured and connected servers, but currently has no way to surface servers that failed to start.\n\nNeeded:\n1. Parse `mcp_server_errors` from the headless init event in `claude-sdk.ts` and include it in the MCP state broadcast.\n2. Surface failed servers with their error reason in the MCP panel — either inline on the server row (a red error badge) or as a dedicated \"failed to start\" section.\n3. Coordinate with `ProviderMcpServerStatus` (`failed` state): ensure `mcp_server_errors` entries map correctly to `failed` status.\n\nScope: small–medium (~2h). Touch points: `claude-sdk.ts` (init handler), MCP state broadcast, MCP panel UI.\n\nBucket 2 — priority 2.\n\nRef: @anthropic-ai/claude-code CHANGELOG v2.1.219",
+      "status": "open",
+      "priority": 2,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "claude",
+        "bucket-2"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-07-27T00:00:00.000Z",
+      "updatedAt": "2026-07-27T00:00:00.000Z"
+    },
+    {
+      "id": "29a4c7e1",
+      "title": "Codex: investigate executor-provided skill discovery for cross-provider skill surface",
+      "description": "Codex CLI 0.146.0 (2026-07-29) adds skill discovery from the executor: \"Discover executor-provided skills and securely read their associated resources, including explicitly selected skills.\" In the Codex app-server model, the \"executor\" is the process that manages the app-server connection — which is Relay.\n\nThis means Relay can now publish a skill manifest to Codex sessions so the model can discover and invoke Relay-defined skills. Relay already surfaces Claude Code skills (from `.claude.json`) in the skills panel and supports skill invocation via slash commands for Claude sessions. Making this work for Codex would be on-strategy cross-provider normalization.\n\n**Would be bucket 2 if `ProviderCapabilities` had an `executorSkills` abstraction** — a provider-neutral way for Relay to declare that it can expose a skill manifest to the provider's session, and for the provider driver to implement the publishing protocol. Without that abstraction, this is bucket 3 (new surface needing design).\n\nResearch questions before scoping:\n1. What is the app-server RPC for executor-side skill publishing? (New method in the JSON-RPC protocol, or a field in the `session/init` handshake?)\n2. What is the skill manifest format — is it the same as Claude Code's `.claude.json` skills schema or codex-specific?\n3. Does Codex expose skill invocation through the app-server notification stream (so Relay can route the call), or does it invoke the executor directly?\n\nIf the protocol is documented or inspectable from the Codex source, this may be near-mechanical. If undocumented, this needs a research pass first.\n\nRef: github.com/openai/codex releases v0.146.0\n\nBucket 3 (passes chase test: cross-provider skill normalization) — priority 3.",
+      "status": "open",
+      "priority": 3,
+      "type": "task",
+      "tags": [
+        "provider-watch",
+        "codex",
+        "bucket-3"
+      ],
+      "parent": null,
+      "blockedBy": [],
+      "createdAt": "2026-08-03T00:00:00.000Z",
+      "updatedAt": "2026-08-03T00:00:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
This is the automated weekly sweep of Claude and Codex release notes. It reads what changed upstream since the last checked marker, files to-dos for anything that touches Relay's integration layer, and moves the "last checked" marker forward. **Merging this PR accepts the filed to-dos and advances the watermarks. It touches zero app code.**

A prior session ran a triage for 2026-07-20 → 2026-07-27 but never pushed those commits to main. This PR absorbs that run in full — all 8 tasks from that session are carried forward verbatim, none dropped. This run then covers 2026-07-27 → 2026-08-03 on top of that.

---

## Needs attention before the next Claude SDK upgrade

Two changes in the Anthropic SDK (0.112.3 → 0.115.0) require handling before Relay upgrades past those versions:

**`model_context_window_exceeded` stop reason** (SDK 0.114.0, task `a1f3e820`, priority 1): When a session runs out of context window, the SDK now returns a distinct stop reason instead of `end_turn`. Without explicit handling in `handleResult`, a context-full session silently looks like a completed turn — users see nothing unusual and don't know the session is stuck. Needs a visible error state in the chat UI.

**`tool_change` streaming events and tool add/remove blocks** (SDK 0.115.0, task `b2c4d951`, priority 1): New streaming event type and new message block shapes for dynamic tool management. If the live-stream handler or JSONL replayer encounters these without a handler, the result is either silent content loss or a throw on any exhaustiveness check. Needs at minimum a graceful no-op before the SDK pin is bumped to 0.115.0+.

---

## Needs attention — agent SDK permission-mode hardening

**`set_permission_mode` now throws on unrecognized values** (Agent SDK 0.3.214, task `e4b71c9f`, priority 1 — *already in main, adding for visibility*): SDK 0.3.214 changed `set_permission_mode` from silently ignoring unknown values to raising a visible error. A DB edge case, null fallback, or gap in the mode-mapping exhaustiveness check would now surface as a live session error. Needs an audit of every `set_permission_mode` call site.

---

## To-dos filed

### Carried forward from 2026-07-27 run (Claude 2.1.215→2.1.220 / Agent SDK 0.3.215→0.3.220 / Anthropic SDK 0.112.3→0.115.0)

**Tool result disposition labels** (`c3d5f062`, priority 2): Agent SDK 0.3.216 added a machine-readable field to user messages that says whether a tool result was denied, interrupted, or cancelled. Relay currently infers this from prose text-matching. The new field enables accurate labels in the tool-result renderer for all three cases.

**Better model tracking via billing IDs** (`d4e6a173`, priority 2): Agent SDK 0.3.218 added `canonicalModel` and `provider` to every per-turn usage entry. These are the authoritative billing-level model identifiers, more reliable than the current inference from SDK info. Using them for `lastTurnModel` tracking fixes potential mispricing when alias IDs differ from canonical IDs.

**Cancel queued turns on stop** (`e5f7b284`, priority 2): Agent SDK 0.3.219 adds an opt-in `cancel_queued` flag to the interrupt request, gated by a session capability. Without it, pressing stop only halts the current turn — queued messages in a pipeline keep running. Add the flag when the session advertises the capability, with optional UI differentiation between "stop now" and "stop and clear queue."

**Fast-mode disabled reason** (`f6a8c395`, priority 2): Agent SDK 0.3.219 adds a string explaining why fast mode is unavailable (policy, plan tier, model mismatch). Surface it as a tooltip on the disabled toggle so users know whether they can address it.

**Network-level sandbox isolation** (`07b9d406`, priority 2): CLI 2.1.219 and Agent SDK 0.3.219 add a `sandbox.network.strictAllowlist` session setting that blocks sandboxed commands from reaching unlisted hosts. Relay has no concept of network sandboxing. File a `ProviderCapabilities` flag and expose the setting in session creation / project settings.

**MCP startup failures in status UI** (`18ca0517`, priority 2): CLI 2.1.219 adds a `mcp_server_errors` array to the headless init event listing MCP servers that failed config validation at startup. The MCP panel shows configured and connected servers but has no "failed to start" state. Parse the field and map failures to the existing `ProviderMcpServerStatus.failed` state.

**Subagent-type kickback note added** (`f8c1a047` — already in main): Updated task description with a kickback note from 2026-07-29: the agents sidecar tab doesn't exist yet (`SidecarTab` has no `"agents"` entry), so this task needs the agents sidecar design to land first. Same blocker as `ffbc884b`.

### New this run (Codex 0.146.0, released 2026-07-29)

**Executor-provided skill discovery** (`29a4c7e1`, priority 3): Codex 0.146.0 lets the executor (Relay) publish a skill manifest that Codex sessions can discover and invoke. Relay already surfaces Claude skills in the UI and supports slash-command invocation. Making this work across both providers via a shared `ProviderCapabilities` layer would be on-strategy cross-provider normalization. Needs a research pass first: the app-server RPC for skill publishing and the manifest format are not yet documented in the Relay codebase.

---

## No action needed

- **Codex: session naming with `/new` and `/clear`, thread pinning** — CLI-level UX changes inside the Codex session. Relay manages sessions at a higher layer and has its own pinning. Passes through.
- **Codex: remote Code Mode host via WebSocket** — Codex can now connect to a remote execution host instead of the local binary. For Relay-managed local sessions, `CODEX_CODE_MODE_HOST_PATH` injection is unchanged.
- **Codex: web search for custom model providers** — expands existing web search support. The `web_search_call` event type is already parsed in Relay's Codex JSONL handler.
- **Codex: proxy support across auth, downloads, MCP auth, WebSockets** — transparent passthrough; proxy fixes in the Codex process benefit Relay sessions automatically.
- **Codex: MCP connection resilience improvements** — same; improves stability transparently.
- **Codex: message preservation during interruptions** — bug fix; Relay's interrupt/cancel flow is not protocol-impacted.

---

## Skipped — not Relay's concern

- **Codex Agent Plugins manifests + Amazon Bedrock / Claude Code plugin marketplaces**: Codex's native plugin marketplace is a different layer from Relay's plugin system. No integration surface.

---

## Blocked on missing groundwork

**Codex thread forking** is not separately filed. Codex 0.146.0 ships "Fork threads with paginated history, including temporary forks that do not appear in thread listings" — this is now the Codex-side equivalent of Claude's `rewind_conversation` branching primitive. The existing task `a5d82c63` ("design session branching via rewind_conversation primitive") covers the provider-neutral abstraction design, and its description has been updated to note the Codex equivalent now exists. The implementation tasks for both providers will follow once the abstraction is designed.

**Codex executor skill discovery** (`29a4c7e1`) would be a near-mechanical capability-declaration task if `ProviderCapabilities` had an `executorSkills` abstraction. It doesn't yet, so this needs design before it can be implemented.

---

## Watermarks advanced

| Source | Before | After |
|--------|--------|-------|
| Claude Code CLI | 2.1.215 | 2.1.220 |
| Claude Agent SDK | 0.3.215 | 0.3.220 |
| Anthropic SDK | 0.112.3 | 0.115.0 |
| Codex CLI | 0.144.6 | 0.146.0 |
| Codex app-server | 0.144.6 | 0.146.0 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Reju1bVEswnqX7ygTNo41o)_